### PR TITLE
BAU: Add an action to report results to the job summary

### DIFF
--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -1,7 +1,6 @@
 name: Beautify branch name test
 
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   run-tests:

--- a/.github/workflows/test-get-stale-stacks.yml
+++ b/.github/workflows/test-get-stale-stacks.yml
@@ -1,7 +1,6 @@
 name: Get stale stacks test
 
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   run-tests:

--- a/.github/workflows/test-report-step-result.yml
+++ b/.github/workflows/test-report-step-result.yml
@@ -1,0 +1,138 @@
+name: Report step result test
+
+on: pull_request
+
+jobs:
+  run-tests:
+    name: Test action
+    runs-on: ubuntu-latest
+    env:
+      REPORT_FILE_NAME: test-result.txt
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+      - name: Write stub report
+        env:
+          REPORT_FILE: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+        run: echo "Stub result" >> "$REPORT_FILE"
+
+
+      - name: Report result
+        uses: ./report-step-result
+        with:
+          file-path: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+          output-file-path: ${{ runner.temp }}/report.txt
+          code-block: false
+
+      - name: Check result reported
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report.txt
+          EXPECTED_FILE: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+        run: |
+          [[ $(cat "$OUTPUT_FILE") == $(cat "$EXPECTED_FILE") ]]
+
+
+      - name: Accumulate results
+        uses: ./report-step-result
+        with:
+          file-path: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+          output-file-path: ${{ runner.temp }}/report.txt
+          code-block: false
+
+      - name: Check result accumulated
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Stub result
+          Stub result
+          
+          EOF
+          
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Include title
+        uses: ./report-step-result
+        with:
+          file-path: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+          output-file-path: ${{ runner.temp }}/report-with-title.txt
+          code-block: false
+          title: Report title
+
+      - name: Check title included
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-with-title.txt
+        run: |
+          cat << 'EOF' > expected_file
+          **Report title**
+          Stub result
+          
+          EOF
+          
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Use code block
+        uses: ./report-step-result
+        with:
+          file-path: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+          output-file-path: ${{ runner.temp }}/report-code-block.txt
+          code-block: true
+
+      - name: Check title included
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-code-block.txt
+        run: |
+          cat << 'EOF' > expected_file
+          ```
+          Stub result
+          ```
+          EOF
+          
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Use syntax highlighting
+        uses: ./report-step-result
+        with:
+          file-path: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+          output-file-path: ${{ runner.temp }}/report-syntax-highlight.txt
+          code-block: true
+          language: shell
+
+      - name: Check syntax highlighting used
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-syntax-highlight.txt
+        run: |
+          cat << 'EOF' > expected_file
+          ```shell
+          Stub result
+          ```
+          EOF
+          
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Use all elements
+        uses: ./report-step-result
+        with:
+          file-path: ${{ runner.temp }}/${{ env.REPORT_FILE_NAME }}
+          output-file-path: ${{ runner.temp }}/report-all-elements.txt
+          title: Report title
+          code-block: true
+          language: shell
+
+      - name: Check all elements used
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-all-elements.txt
+        run: |
+          cat << 'EOF' > expected_file
+          **Report title**
+          ```shell
+          Stub result
+          ```
+          EOF
+          
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]

--- a/report-step-result/action.yaml
+++ b/report-step-result/action.yaml
@@ -1,0 +1,31 @@
+name: 'Print a file to the job summary'
+description: 'Print the specified file to the current job summary with optional syntax highlighting'
+inputs:
+  file-path:
+    description: 'Path to the file to append to the job summary'
+    required: true
+  title:
+    description: 'Message to print above the report'
+    required: false
+  code-block:
+    description: 'Print the file contents in a code block'
+    required: false
+    default: 'true'
+  language:
+    description: 'Language to use for syntax highlighting when printing the file contents in a code block'
+    required: false
+  output-file-path:
+    description: 'Override the default destination and write the output to the specified file instead'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - name: Append to step summary
+      run: $GITHUB_ACTION_PATH/append-to-step-summary.sh
+      shell: bash
+      env:
+        FILE_PATH: ${{ inputs.file-path }}
+        TITLE: ${{ inputs.title }}
+        CODE_BLOCK: ${{ inputs.code-block }}
+        LANGUAGE: ${{ inputs.language }}
+        OUT_FILE: ${{ inputs.output-file-path }}

--- a/report-step-result/append-to-step-summary.sh
+++ b/report-step-result/append-to-step-summary.sh
@@ -1,0 +1,18 @@
+set -eu
+
+file=${FILE_PATH}
+message=${TITLE}
+language=${LANGUAGE}
+output_file=${OUT_FILE:-$GITHUB_STEP_SUMMARY}
+
+use_code_block=false
+[[ ${CODE_BLOCK} == true ]] && use_code_block=true
+
+{
+  [[ $message ]] && echo "**$message**"
+  $use_code_block && echo '```'"$language"
+  cat "$file"
+  $use_code_block && echo '```'
+} >> "$output_file"
+
+echo "The result has been written to ${OUT_FILE:-the job summary}"


### PR DESCRIPTION
The action allows to print the contents of a file to the [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
) and optionally wrap it in a code block with syntax highlighting.