### PR TITLE
[SPOT-548] Add beta features boolean

### DIFF
--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: 'AWS region to use'
     required: false
     default: eu-west-2
+  enable-beta-features:
+    type: boolean
+    required: false
+    description: 'Optionally enable SAM beta features'
+    default: false
 runs:
   using: composite
   steps:
@@ -27,7 +32,15 @@ runs:
       run: sam validate ${TEMPLATE_FILE:+--template-file $TEMPLATE_FILE}
 
     - name: Build SAM Application
+      if: ${{ !inputs.enable-beta-features }}
       shell: bash
       env:
         TEMPLATE_FILE: ${{ inputs.sam-template-file }}
       run: sam build --cached --parallel ${TEMPLATE_FILE:+--template-file $TEMPLATE_FILE}
+
+    - name: Build SAM Application (with Beta Features)
+      if: ${{ inputs.enable-beta-features }}
+      shell: bash
+      env:
+        TEMPLATE_FILE: ${{ inputs.sam-template-file }}
+      run: sam build --beta-features --cached --parallel ${TEMPLATE_FILE:+--template-file $TEMPLATE_FILE}


### PR DESCRIPTION
## What?
As part of our tests of switching over to Node/Typescript for certain components of SPOT, we'd like to be able to enable the `--beta-features` flag on the SAM CLI.