### PR TITLE
BAU: Add an action to parse key=value pair parameters

### DIFF
--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -23,6 +23,18 @@ jobs:
           [[ ${{ steps.downcase.outputs.pretty-branch-name }} == branch-name-with-upper-case-letters ]]
 
 
+      - name: Do not downcase branch name
+        id: downcase-not
+        uses: ./beautify-branch-name
+        with:
+          branch-name: BRANCH-NAME-with-UPPer-CASe-letterS
+          downcase: false
+
+      - name: Check branch name not downcased
+        run: |
+          [[ ${{ steps.downcase-not.outputs.pretty-branch-name }} == BRANCH-NAME-with-UPPer-CASe-letterS ]]
+
+
       - name: Replace underscores
         id: replace-underscores
         uses: ./beautify-branch-name
@@ -33,6 +45,18 @@ jobs:
       - name: Check underscores replaced
         run: |
           [[ ${{ steps.replace-underscores.outputs.pretty-branch-name }} == branch-name-with-underscores ]]
+          
+
+      - name: Do not replace underscores
+        id: replace-underscores-not
+        uses: ./beautify-branch-name
+        with:
+          branch-name: branch_name_with-underscores
+          underscores-to-hyphens: false
+
+      - name: Check underscores not replaced
+        run: |
+          [[ ${{ steps.replace-underscores-not.outputs.pretty-branch-name }} == branch_name_with-underscores ]]
 
 
       - name: Truncate length

--- a/.github/workflows/test-parse-parameters.yml
+++ b/.github/workflows/test-parse-parameters.yml
@@ -1,0 +1,111 @@
+name: Parse parameters test
+
+on: pull_request
+
+jobs:
+  run-tests:
+    name: Test action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+
+      - name: Parse single-line parameters
+        id: parse-single-line-params
+        uses: ./parse-parameters
+        with:
+          parameters: sky=blue | test="foo bar"
+          associative-array: true
+
+      - name: Check single-line parameters parsed
+        run: |
+          [[ "${{ steps.parse-single-line-params.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]
+
+
+      - name: Parse single-line parameters without quotes
+        id: parse-single-line-params-no-quotes
+        uses: ./parse-parameters
+        with:
+          parameters: sky=blue | test=foo bar
+          associative-array: true
+
+      - name: Check single-line parameters without quotes parsed
+        run: |
+          [[ "${{ steps.parse-single-line-params-no-quotes.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]
+
+
+      - name: Parse compact single-line parameters
+        id: parse-single-line-params-compact
+        uses: ./parse-parameters
+        with:
+          parameters: sky=blue|test="foo bar"
+          associative-array: true
+
+      - name: Check compact single-line parameters parsed
+        run: |
+          [[ "${{ steps.parse-single-line-params-compact.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]
+
+      - name: Parse single-line parameters with spaces
+        id: parse-single-line-params-spaces
+        uses: ./parse-parameters
+        with:
+          parameters: sky = blue | test = foo bar
+          associative-array: true
+
+      - name: Check single-line parameters with spaces parsed
+        run: |
+          [[ "${{ steps.parse-single-line-params-spaces.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]
+
+
+      - name: Parse single-line parameters into key-value pairs
+        id: parse-single-line-params-kvps
+        uses: ./parse-parameters
+        with:
+          parameters: sky=blue | test="foo bar"
+          associative-array: false
+
+      - name: Check single-line parameters parsed into key-value pairs
+        run: |
+          [[ "${{ steps.parse-single-line-params-kvps.outputs.parsed-parameters }}" == "sky='blue' test='foo bar'" ]]
+
+
+      - name: Parse multi-line parameters
+        id: parse-multi-line-params
+        uses: ./parse-parameters
+        with:
+          associative-array: true
+          parameters: |
+            sky=blue
+            test="foo bar"
+
+      - name: Check multi-line parameters parsed
+        run: |
+          [[ "${{ steps.parse-multi-line-params.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]
+
+
+      - name: Parse multi-line parameters without quotes
+        id: parse-multi-line-params-no-quotes
+        uses: ./parse-parameters
+        with:
+          associative-array: true
+          parameters: |
+            sky=blue
+            test=foo bar
+
+      - name: Check multi-line parameters without quotes parsed
+        run: |
+          [[ "${{ steps.parse-multi-line-params-no-quotes.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]
+
+      - name: Parse multi-line parameters with spaces
+        id: parse-multi-line-params-spaces
+        uses: ./parse-parameters
+        with:
+          associative-array: true
+          parameters: |
+            sky = blue
+            test = foo bar
+
+      - name: Check multi-line parameters parsed
+        run: |
+          [[ "${{ steps.parse-multi-line-params-spaces.outputs.parsed-parameters }}" == "[sky]='blue' [test]='foo bar'" ]]

--- a/beautify-branch-name/action.yml
+++ b/beautify-branch-name/action.yml
@@ -38,8 +38,8 @@ runs:
       shell: bash
       env:
         BRANCH_NAME: ${{ inputs.branch-name }}
-        DOWNCASE_NAME: ${{ inputs.downcase }}
-        UNDERSCORES_TO_HYPHENS: ${{ inputs.underscores-to-hyphens }}
+        DOWNCASE_NAME: ${{ inputs.downcase == 'true' }}
+        UNDERSCORES_TO_HYPHENS: ${{ inputs.underscores-to-hyphens == 'true' }}
         TOTAL_LENGTH_LIMIT: ${{ inputs.length-limit }}
         PREFIX: ${{ inputs.prefix }}
         SET_ENV_VAR: ${{ inputs.set-env-var }}

--- a/beautify-branch-name/transform-branch-name.sh
+++ b/beautify-branch-name/transform-branch-name.sh
@@ -1,15 +1,11 @@
 set -eu
 
 branch_name=${PREFIX:+$PREFIX-}${BRANCH_NAME:-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}}
+replace_underscores=${UNDERSCORES_TO_HYPHENS}
 length_limit=${TOTAL_LENGTH_LIMIT}
+downcase=${DOWNCASE_NAME}
 env_var=${SET_ENV_VAR}
 message=${USAGE}
-
-replace_underscores=false
-[[ ${UNDERSCORES_TO_HYPHENS} == true ]] && replace_underscores=true
-
-downcase=false
-[[ ${DOWNCASE_NAME} == true ]] && downcase=true
 
 if [[ $length_limit -lt 1 ]]; then
   echo "Invalid length limit: $length_limit - must be greater than 0"

--- a/code-quality/check-shell-scripts/action.yml
+++ b/code-quality/check-shell-scripts/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Run shellcheck
       id: run-shellcheck
-      if: ${{ env.SCRIPTS && inputs.run-shellcheck }}
+      if: ${{ env.SCRIPTS && inputs.run-shellcheck == 'true' }}
       shell: bash
       env:
         DIALECT: ${{ inputs.shell }}
@@ -73,7 +73,7 @@ runs:
 
     - name: Run shfmt
       id: run-shfmt
-      if: ${{ ((success() && env.SCRIPTS) || (failure() && steps.run-shellcheck.outcome == 'failure')) && inputs.run-shfmt }}
+      if: ${{ ((success() && env.SCRIPTS) || (failure() && steps.run-shellcheck.outcome == 'failure')) && inputs.run-shfmt == 'true' }}
       shell: bash
       env:
         OUTPUT_FILE: ${{ runner.temp }}/shfmt.output

--- a/code-quality/check-shell-scripts/action.yml
+++ b/code-quality/check-shell-scripts/action.yml
@@ -84,7 +84,7 @@ runs:
     - name: Write shellcheck results
       id: report-shellcheck
       if: ${{ failure() && steps.run-shellcheck.outcome == 'failure' }}
-      uses: alphagov/di-github-actions/report-step-result@a142f7f22cc41ce8466e32deb68ff4994bee3e4c
+      uses: alphagov/di-github-actions/report-step-result@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         file-path: ${{ runner.temp }}/shellcheck.output
         output-file-path: ${{ runner.temp }}/checks.report
@@ -94,7 +94,7 @@ runs:
     - name: Write shfmt results
       id: report-shfmt
       if: ${{ failure() && steps.run-shfmt.outcome == 'failure' }}
-      uses: alphagov/di-github-actions/report-step-result@a142f7f22cc41ce8466e32deb68ff4994bee3e4c
+      uses: alphagov/di-github-actions/report-step-result@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         file-path: ${{ runner.temp }}/shfmt.output
         output-file-path: ${{ runner.temp }}/checks.report
@@ -103,7 +103,7 @@ runs:
 
     - name: Report results
       if: ${{ failure() && (steps.report-shellcheck.outcome == 'success' || steps.report-shfmt.outcome == 'success') }}
-      uses: alphagov/di-github-actions/report-step-result@a142f7f22cc41ce8466e32deb68ff4994bee3e4c
+      uses: alphagov/di-github-actions/report-step-result@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         file-path: ${{ runner.temp }}/checks.report
         code-block: false

--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -61,6 +61,6 @@ runs:
 
     - name: Report Checkov result
       if: ${{ failure() && steps.run-checkov.outcome == 'failure' }}
-      uses: alphagov/di-github-actions/report-step-result@a142f7f22cc41ce8466e32deb68ff4994bee3e4c
+      uses: alphagov/di-github-actions/report-step-result@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         file-path: ${{ runner.temp }}/checkov.output

--- a/parse-parameters/action.yml
+++ b/parse-parameters/action.yml
@@ -1,0 +1,28 @@
+name: 'Parse parameters'
+description: 'Parse parameters encoded as key-value pairs delimited by "|" or newlines into a key=value pairs string'
+inputs:
+  parameters:
+    description: 'The parameters to parse'
+    required: true
+  env-var-name:
+    description: 'Name of an env var to store a string representation of an associative array containing the parsed params'
+    required: false
+  associative-array:
+    description: "Encode output as a string representing an associative array ([key1]=value1 ... [keyN]=valueN)"
+    required: false
+    default: 'false'
+outputs:
+  parsed-parameters:
+    description: 'A string representation of a regular or an associative array containing the parsed params'
+    value: ${{ steps.parse-parameters.outputs.parsed-parameters }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Parse parameters
+      id: parse-parameters
+      run: ${{ github.action_path }}/parse-params.sh
+      shell: bash
+      env:
+        PARAMS: ${{ inputs.parameters }}
+        ENV_VAR_NAME: ${{ inputs.env-var-name }}
+        ASSOCIATIVE_ARRAY: ${{ inputs.associative-array == 'true' }}

--- a/parse-parameters/parse-params.sh
+++ b/parse-parameters/parse-params.sh
@@ -1,0 +1,29 @@
+set -eu
+
+raw_parameters=$(echo -n "${PARAMS}")
+associative_arr=${ASSOCIATIVE_ARRAY}
+env_var=${ENV_VAR_NAME}
+
+num_lines=$(wc -l <<< "$raw_parameters")
+if [[ $num_lines -le 1 ]]; then
+  IFS="|" read -ra key_value_pairs <<< "$raw_parameters"
+else
+  mapfile -t key_value_pairs <<< "$raw_parameters"
+fi
+
+parameters=()
+for kvp in "${key_value_pairs[@]}"; do
+  IFS="=" read -r name value < <(xargs <<< "$kvp")
+  name=$(xargs <<< "$name") && value=$(xargs <<< "$value")
+  $associative_arr && element="[$name]='$value'" || element="$name='$value'"
+  parameters+=("$element")
+done
+
+echo "::set-output name=parsed-parameters::${parameters[*]}"
+
+if [[ $env_var ]]; then
+  echo "Setting environment variable $env_var..."
+  echo "$env_var=${parameters[*]}" >> "$GITHUB_ENV"
+fi
+
+echo "Parsed ${#parameters[@]} parameters"

--- a/report-step-result/action.yml
+++ b/report-step-result/action.yml
@@ -29,8 +29,8 @@ runs:
       shell: bash
       env:
         FILE_PATH: ${{ inputs.file-path }}
-        TITLE: ${{ inputs.title }}
-        CODE_BLOCK: ${{ inputs.code-block }}
-        LANGUAGE: ${{ inputs.language }}
         OUT_FILE: ${{ inputs.output-file-path }}
-        FAIL_IF_FILE_MISSING: ${{ inputs.fail-if-report-missing }}
+        TITLE: ${{ inputs.title }}
+        LANGUAGE: ${{ inputs.language }}
+        CODE_BLOCK: ${{ inputs.code-block == 'true' }}
+        FAIL_IF_FILE_MISSING: ${{ inputs.fail-if-report-missing == 'true' }}

--- a/report-step-result/append-to-step-summary.sh
+++ b/report-step-result/append-to-step-summary.sh
@@ -1,15 +1,11 @@
 set -eu
 
 file=${FILE_PATH}
+output_file=${OUT_FILE:-$GITHUB_STEP_SUMMARY}
 message=${TITLE}
 language=${LANGUAGE}
-output_file=${OUT_FILE:-$GITHUB_STEP_SUMMARY}
-
-use_code_block=false
-[[ ${CODE_BLOCK} == true ]] && use_code_block=true
-
-fail_if_missing=false
-[[ ${FAIL_IF_FILE_MISSING} == true ]] && fail_if_missing=true
+use_code_block=${CODE_BLOCK}
+fail_if_missing=${FAIL_IF_FILE_MISSING}
 
 if ! [[ -f $file ]]; then
   echo "::warning title=Report missing::File $file has not been found"

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Name of the SAM template file to use'
     required: false
   aws-role-arn:
-    description: 'Aws role ARN to assume when validating the template'
+    description: 'AWS role ARN to assume when validating the template'
     required: true
   aws-region:
     description: 'AWS region to use'

--- a/sam/check-stacks-exist/action.yml
+++ b/sam/check-stacks-exist/action.yml
@@ -25,4 +25,4 @@ runs:
       env:
         STACK_NAMES: ${{ inputs.stack-names }}
         SET_ENV_VAR: ${{ inputs.set-env-var }}
-        VERBOSE: ${{ inputs.verbose }}
+        VERBOSE: ${{ inputs.verbose == 'true' }}

--- a/sam/check-stacks-exist/check-stacks-exist.sh
+++ b/sam/check-stacks-exist/check-stacks-exist.sh
@@ -1,10 +1,9 @@
 set -eu
 
 env_var=${SET_ENV_VAR}
-read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
+print_summary=${VERBOSE}
 
-print_summary=false
-[[ ${VERBOSE} == true ]] && print_summary=true
+read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
 
 real_stacks=()
 fake_stacks=()

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -29,5 +29,5 @@ runs:
       shell: bash
       env:
         STACK_NAMES: ${{ steps.check-stacks-exist.outputs.existing-stacks }}
-        ONLY_FAILED: ${{ inputs.only-if-failed }}
+        ONLY_FAILED: ${{ inputs.only-if-failed == 'true' }}
         AWS_REGION: ${{ inputs.aws-region }}

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Check stacks exist
       id: check-stacks-exist
       if: ${{ inputs.stack-names }}
-      uses: alphagov/di-github-actions/sam/check-stacks-exist@a142f7f22cc41ce8466e32deb68ff4994bee3e4c
+      uses: alphagov/di-github-actions/sam/check-stacks-exist@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         stack-names: ${{ inputs.stack-names }}
         verbose: true

--- a/sam/delete-stacks/delete-stacks.sh
+++ b/sam/delete-stacks/delete-stacks.sh
@@ -1,10 +1,9 @@
 set -eu
 
-read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
 region=${AWS_REGION}
+delete_only_failed=${ONLY_FAILED}
 
-delete_only_failed=false
-[[ ${ONLY_FAILED} == true ]] && delete_only_failed=true
+read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
 
 deleted_stacks=()
 failed_stacks=()

--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -37,21 +37,21 @@ runs:
     - name: Parse parameters
       id: parse-parameters
       if: ${{ inputs.parameters != null }}
-      uses: alphagov/di-github-actions/parse-parameters@c5ad1d33aa2b68287ec09f454f5a5c6eaf046ae0
+      uses: alphagov/di-github-actions/parse-parameters@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         parameters: ${{ inputs.parameters }}
 
     - name: Parse tags
       id: parse-tags
       if: ${{ inputs.tags != null }}
-      uses: alphagov/di-github-actions/parse-parameters@c5ad1d33aa2b68287ec09f454f5a5c6eaf046ae0
+      uses: alphagov/di-github-actions/parse-parameters@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         parameters: ${{ inputs.tags }}
 
     - name: Get stack name from branch
       id: set-stack-name
       if: ${{ inputs.stack-name == null }}
-      uses: alphagov/di-github-actions/beautify-branch-name@c5ad1d33aa2b68287ec09f454f5a5c6eaf046ae0
+      uses: alphagov/di-github-actions/beautify-branch-name@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         prefix: ${{ inputs.stack-name-prefix }}
         length-limit: 150
@@ -65,7 +65,7 @@ runs:
 
     - name: Delete failed stack
       if: ${{ inputs.delete-failed-stack == 'true' }}
-      uses: alphagov/di-github-actions/sam/delete-stacks@c5ad1d33aa2b68287ec09f454f5a5c6eaf046ae0
+      uses: alphagov/di-github-actions/sam/delete-stacks@f5dbfa65c3d3e100b12413dd6816176783ce8308
       with:
         only-if-failed: true
         stack-names: ${{ env.STACK_NAME }}

--- a/sam/get-stale-stacks/action.yml
+++ b/sam/get-stale-stacks/action.yml
@@ -2,28 +2,35 @@ name: 'Get stale stacks'
 description: 'Retrieve names of AWS SAM stacks older than a set threshold, and filtered by name and tags'
 inputs:
   threshold-days:
-    description: "Get stacks older than the specified number of days"
+    description: 'Get stacks older than the specified number of days'
     required: false
-    default: "30"
+    default: '30'
   stack-name-filter:
-    description: "Only retrieve stacks whose names contain the specified string"
+    description: 'Only retrieve stacks whose names contain the specified string'
     required: false
   stack-tag-filters:
-    description: "Filter stacks by tags - encoded as name=value pairs, separated by ' | ' (e.g. 'tag1=val1 | tag2=val 2')"
+    description: 'Filter stacks by tags, encoded as name=value pairs separated by newlines or "|"'
     required: false
   env-var-name:
-    description: "Accumulate stack names in the environment variable with the specified name, persisted in the job"
+    description: 'Accumulate stack names in the environment variable with the specified name, persisted in the job'
     required: false
   description:
     description: 'Description of the stale stacks - for logging purposes only'
     required: false
 outputs:
   stack-names:
-    description: "Filtered stack names"
+    description: 'Filtered stack names'
     value: ${{ steps.filter-stacks.outputs.stack-names }}
 runs:
   using: 'composite'
   steps:
+    - name: Parse tag filters
+      id: parse-tag-filters
+      uses: alphagov/di-github-actions/parse-parameters@f5dbfa65c3d3e100b12413dd6816176783ce8308
+      with:
+        parameters: ${{ inputs.stack-tag-filters }}
+        associative-array: true
+
     - name: Filter stacks
       id: filter-stacks
       run: ${{ github.action_path }}/filter-stacks.sh
@@ -31,6 +38,6 @@ runs:
       env:
         THRESHOLD_DAYS: ${{ inputs.threshold-days }}
         STACK_NAME_FILTER: ${{ inputs.stack-name-filter }}
-        STACK_TAG_FILTERS: ${{ inputs.stack-tag-filters }}
+        STACK_TAG_FILTERS: ${{ steps.parse-tag-filters.outputs.parsed-parameters }}
         ENV_VAR_NAME: ${{ inputs.env-var-name }}
         STACKS_DESCRIPTION: ${{ inputs.description }}


### PR DESCRIPTION
The action can be used in other actions to decode key-value pair arguments. The output is a string that can be parsed into a regular bash array or an associative array.

  - Use the parse params action in the `get-stale-stacks` action

Usage examples:
```yaml
parameters: hello=world | sky = blue
tags: |
   myTag=myValue
   otherTag = otherValue
```

Output:
```bash
# Regular array string
"hello=world sky=blue"

# Associative array string
"[myTag]=myValue [otherTag]=otherValue"
```
---
  - Better booleans 

Let the switch env vars be passed through as booleans rather than strings, so they can be used in the scripts directly without having to check the value.