### PR TITLE
BAU: Make the PaaS cleanup job more robust

### DIFF
--- a/paas/delete-stale-apps/action.yml
+++ b/paas/delete-stale-apps/action.yml
@@ -17,10 +17,10 @@ runs:
         echo "Cut off date: $cut_off_date"
         
         for app in $(cf apps | awk 'NR>3 {print $1}'); do
-          last_upload_date=$(cf events "$app" | grep audit.app.package.upload | awk 'NR==1 {print $1}')
+          last_upload_date=$(cf events "$app" | grep audit.app.package.upload | awk 'NR==1 {print $1}') || true
           echo "$app | last uploaded: $last_upload_date"
         
           if [[ -z $last_upload_date || $(date -d "$last_upload_date" +%Y-%m-%d) < $cut_off_date ]]; then
-            cf delete "$app" -rf
+            cf delete "$app" -rf || true
           fi
         done


### PR DESCRIPTION
Don't fail the job if an app has a missing upload event or fails to get deleted.

The app will get deleted if the event is missing. If the delete command fails, the job will continue running for other apps.