### PR TITLE
BAU - Beautify dependabot branch names

### DIFF
--- a/beautify-branch-name/action.yml
+++ b/beautify-branch-name/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Whether to replace all underscores with hyphens'
     required: false
     default: 'true'
+  tidy-dependabot-branch:
+    description: 'Whether to beautify dependabot generated branch names to db-function-package-version'
+    required: false
+    default: 'false'
   length-limit:
     description: 'Maximum length of the modified string'
     required: false
@@ -40,6 +44,7 @@ runs:
         BRANCH_NAME: ${{ inputs.branch-name }}
         DOWNCASE_NAME: ${{ inputs.downcase == 'true' }}
         UNDERSCORES_TO_HYPHENS: ${{ inputs.underscores-to-hyphens == 'true' }}
+        TIDY_DEPENDENCY_BOT_BRANCH: ${{ inputs.tidy-dependabot-branch == 'true' }}
         TOTAL_LENGTH_LIMIT: ${{ inputs.length-limit }}
         PREFIX: ${{ inputs.prefix }}
         SET_ENV_VAR: ${{ inputs.set-env-var }}

--- a/beautify-branch-name/transform-branch-name.sh
+++ b/beautify-branch-name/transform-branch-name.sh
@@ -2,6 +2,7 @@ set -eu
 
 branch_name=${PREFIX:+$PREFIX-}${BRANCH_NAME:-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}}
 replace_underscores=${UNDERSCORES_TO_HYPHENS}
+tidy_dependabot=${TIDY_DEPENDENCY_BOT_BRANCH}
 length_limit=${TOTAL_LENGTH_LIMIT}
 downcase=${DOWNCASE_NAME}
 env_var=${SET_ENV_VAR}
@@ -16,6 +17,7 @@ echo "Transforming $branch_name..."
 
 $downcase && branch_name=$(echo "$branch_name" | tr '[:upper:]' '[:lower:]')
 $replace_underscores && branch_name=$(echo "$branch_name" | tr '_' '-')
+$tidy_dependabot && branch_name=$(echo "$branch_name" | sed -e 's/dependabot\//db/g' -e 's/gradle//g' -e 's/npm_and_yarn//g' -e 's/-function//g' -e 's/\./-/g' -e 's/\//-/g')
 branch_name=$(echo "$branch_name" | cut -c1-"$length_limit")
 
 echo "::set-output name=pretty-branch-name::$branch_name"


### PR DESCRIPTION
Dependabot generates branch names with slashes and full stops which are not allowed in stack names. Adding functionality to replace those characters with hyphens