### PR TITLE
BAU: Linting checks - add option to treat warnings as errors

### DIFF
--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether to run ESLint'
     required: false
     default: 'true'
+  error-on-warnings:
+    description: 'Treat warnings as errors'
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -58,13 +62,8 @@ runs:
       run: |
         echo "::group::Run Prettier"
         read -ra files <<< "$FILES"
-        
-        if [[ ${#files[@]} -gt 0 ]]; then
-          npx prettier --check "${files[@]}" 2>&1 | tee "$OUTPUT_FILE"
-        else
-          npx prettier --check . 2>&1 | tee "$OUTPUT_FILE"
-        fi
-        
+        [[ ${#files[@]} -eq 0 ]] && files=(.)
+        npx prettier --check "${files[@]}" 2>&1 | tee "$OUTPUT_FILE"        
         echo "::endgroup::"
 
     - name: Run ESLint
@@ -74,12 +73,13 @@ runs:
       env:
         TYPES: .jsx .js .ts
         FILES: ${{ steps.get-files.outputs.files }}
+        STRICT: ${{ inputs.error-on-warnings == 'true' }}
         OUTPUT_FILE: ${{ runner.temp }}/eslint.output
       run: |
         echo "::group::Run ESLint"
-        read -ra files <<< "$FILES"
+        $STRICT && max_warnings="--max-warnings=0"
         
-        if [[ ${#files[@]} -gt 0 ]]; then
+        if [[ -n $FILES ]]; then
           types="$(echo -n "$TYPES" | tr ' ' '\n')"
           files="$(echo -n "$FILES" | tr ' ' '\n')"
         
@@ -88,11 +88,13 @@ runs:
           [[ -z $es_files ]] && echo "No files to check" && exit 0
         
           read -ra es_files <<< "$es_files"
-          npx eslint "${es_files[@]}" | tee "$OUTPUT_FILE"
         else
-          npx eslint . | tee "$OUTPUT_FILE"
+          es_files=(.)
         fi
         
+        npx eslint ${max_warnings:-} "${es_files[@]}" | tee "$OUTPUT_FILE"
+        
+        echo "report-result=true" >> "$GITHUB_OUTPUT"
         echo "::endgroup::"
 
     - name: Write Prettier results
@@ -106,7 +108,7 @@ runs:
 
     - name: Write ESLint results
       id: report-eslint
-      if: ${{ failure() && steps.run-eslint.outcome == 'failure' }}
+      if: ${{ failure() && steps.run-eslint.outcome == 'failure' || steps.run-eslint.outputs.report-result == 'true' }}
       uses: alphagov/di-github-actions/report-step-result@4460b10baa63ab00496fe5f5f39495d428018a27
       with:
         file-path: ${{ runner.temp }}/eslint.output
@@ -114,7 +116,7 @@ runs:
         title: ESLint
 
     - name: Report results
-      if: ${{ failure() && (steps.report-prettier.outcome == 'success' || steps.report-eslint.outcome == 'success') }}
+      if: ${{ (failure() && steps.report-prettier.outcome == 'success') || steps.report-eslint.outcome == 'success' }}
       uses: alphagov/di-github-actions/report-step-result@4460b10baa63ab00496fe5f5f39495d428018a27
       with:
         file-path: ${{ runner.temp }}/checks.report


### PR DESCRIPTION
Always print report for ESLint as warnings may not be flagged as errors, but we always want to see them in the job summary.