### PR TITLE
DFA-2213 DFA-1400: Improvements to Docker image build and linting actions

### DIFF
--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -3,13 +3,16 @@ description: 'Build and push a Docker image to an ECR repo'
 inputs:
   aws-role-arn:
     description: 'ARN of AWS role to assume when authenticating to ECR'
-    required: true
+    required: false
   aws-region:
     description: 'AWS region to use'
     required: false
     default: eu-west-2
   aws-session-name:
     description: 'Override the default AWS session name'
+    required: false
+  registry:
+    description: 'Registry which contains the specified repository'
     required: false
   repository:
     description: 'ECR repository name'
@@ -32,10 +35,28 @@ inputs:
     description: "Path to the directory to build"
     required: false
     default: "."
+outputs:
+  registry:
+    description: "Registry to which the Docker image was pushed"
+    value: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
+  repository:
+    description: "Pass through the repository used to push the Docker image"
+    value: ${{ inputs.repository }}
+  image-version:
+    description: "Pass through the version of the Docker image pushed to ECR"
+    value: ${{ inputs.image-version }}
+  image-digest:
+    description: "Digest of the Docker image pushed to ECR"
+    value: ${{ steps.check-image-exists.outputs.image-digest || steps.report-pushed-image.outputs.image-digest }}
+  image-tags:
+    description: "Pass through the additional tags applied to the Docker image"
+    value: ${{ inputs.image-tags }}
 runs:
   using: composite
   steps:
     - name: Assume AWS Role
+      id: assume-aws-role
+      if: ${{ inputs.aws-role-arn != null }}
       uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
@@ -43,6 +64,7 @@ runs:
         aws-region: ${{ inputs.aws-region }}
 
     - name: Login to ECR
+      if: ${{ inputs.registry == null }}
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
@@ -87,10 +109,10 @@ runs:
 
     - name: Build Docker image
       id: build-image
-      if: ${{ steps.check-image-exists.outputs.image-exists != 'true' }}
+      if: ${{ steps.check-image-exists.outputs.image-exists == 'false' }}
       shell: bash
       env:
-        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_VERSION: ${{ inputs.image-version }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
@@ -109,7 +131,7 @@ runs:
       if: ${{ steps.build-image.outcome == 'success' }}
       shell: bash
       env:
-        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.repository }}
       run: |
         echo "::group::Push image"
@@ -117,12 +139,24 @@ runs:
         echo "::endgroup::"
 
     - name: Report pushed image
+      id: report-pushed-image
       if: ${{ steps.push-docker-image.outcome == 'success' }}
       shell: bash
       env:
-        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.repository }}
       run: |
         mapfile -t tags < <(docker image ls "$REGISTRY/$REPOSITORY" --format '{{.Tag}}')
-        [[ ${#tags[@]} -gt 1 ]] && plural=s
-        IFS=' '; echo "Pushed image with tag${plural:-} \`${tags[*]}\`" >> "$GITHUB_STEP_SUMMARY"
+        mapfile -t digests < <(docker image ls "$REGISTRY/$REPOSITORY" --format '{{.Digest}}' | uniq)
+        
+        if [[ ${#digests[@]} -ne 1 ]]; then
+          echo "Expected one image digest for image $REGISTRY/$REPOSITORY but got \`${digests[*]}\`"
+          exit 1
+        fi
+        
+        digest=${digests[*]}
+        [[ ${#tags[@]} -gt 1 ]] && plural=true
+        [[ ${#tags[@]} -gt 0 ]] && tag_msg="tag${plural:+s} \`${tags[*]}\`"
+        
+        echo "Pushed image with ${tag_msg:-digest \`$digest\`}" >> "$GITHUB_STEP_SUMMARY"
+        echo "image-digest=$digest" >> "$GITHUB_OUTPUT"

--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -76,17 +76,23 @@ runs:
         OUTPUT_FILE: ${{ runner.temp }}/eslint.output
       run: |
         echo "::notice::Running ESLint..."
-        $STRICT && max_warnings="--max-warnings=0"
+        
+        if $STRICT; then
+          max_warnings="--max-warnings=0"
+        fi
         
         if [[ -n $FILES ]]; then
-          types="$(echo -n "$TYPES" | tr ' ' '\n')"
-          files="$(echo -n "$FILES" | tr ' ' '\n')"
+          read -ra types <<< "$(tr '\n' ' ' <<< "$TYPES")"
+          read -ra files <<< "$(tr '\n' ' ' <<< "$FILES")"
         
-          es_files="$(grep -F "$types" <<< "$files" || true)"
-          
-          [[ -z $es_files ]] && echo "No files to check" && exit 0
+          es_files=$(find "${files[@]}" -iregex "$(IFS="|"; echo ".*\.(${types[*]##.})$")")
         
-          read -ra es_files <<< "$es_files"
+          if [[ -z $es_files ]]; then
+            echo "No files to check"
+            exit 0
+          fi
+        
+          mapfile -t es_files <<< "$es_files"
         else
           es_files=(.)
         fi


### PR DESCRIPTION
[DFA-1400: Correctly filter files for ESLint](https://github.com/alphagov/di-github-actions/pull/26/commits/7642b66bdd782ec91106c2b6b699b5a244a2c41e)

The linting action was inadvertently including json files as grep would match the ".json" extension on the ".js" filter.
To solve this, construct a regex to check that the extension matches exactly.

[DFA-2213: Improvements to the build Docker image ECS action](https://github.com/alphagov/di-github-actions/commit/1cf34b5a693be4d0fca26056b6f3467527a4b505) 

- Optional auth to AWS
- Optional log-in to ECR
- Add outputs
- Check number of digests when reporting on the built image

This allows the workflows to be used as a step in another workflow that already has performed AWS and/or ECR auth, and which needs to re-use the input values.