### PR TITLE
DFA-2213: Clean up stale ECS task definitions

### DIFF
--- a/.github/workflows/test-print-list-to-step-summary.yml
+++ b/.github/workflows/test-print-list-to-step-summary.yml
@@ -1,0 +1,161 @@
+name: Print list to step summary test
+
+on: pull_request
+
+jobs:
+  run-tests:
+    name: Test action
+    runs-on: ubuntu-latest
+    env:
+      STUB_REPORT_FILE_NAME: test-result.txt
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+      - name: Write stub report
+        env:
+          REPORT_FILE: ${{ runner.temp }}/${{ env.STUB_REPORT_FILE_NAME }}
+        run: echo "Stub report" >> "$REPORT_FILE"
+
+
+      - name: Report single value
+        uses: ./report-step-result/print-list
+        with:
+          values: one
+          message: Reported values
+          output-file-path: ${{ runner.temp }}/report.txt
+          code-block: false
+
+      - name: Check single value reported
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported values: one
+
+          EOF
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Accumulate results
+        uses: ./report-step-result/print-list
+        with:
+          values: two
+          message: Reported other values
+          output-file-path: ${{ runner.temp }}/report.txt
+          code-block: false
+
+      - name: Check result accumulated
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported values: one
+          Reported other values: two
+
+          EOF
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Use single value message
+        uses: ./report-step-result/print-list
+        with:
+          values: one-and-only
+          message: Reported values
+          single-message: Reported single value
+          output-file-path: ${{ runner.temp }}/report-single-value.txt
+          code-block: false
+
+      - name: Check single value message used
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-single-value.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported single value: one-and-only
+
+          EOF
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Replace token in single value message
+        uses: ./report-step-result/print-list
+        with:
+          values: one-and-only
+          message: Reported values
+          single-message: Reported %s value
+          output-file-path: ${{ runner.temp }}/report-single-value-token.txt
+          code-block: false
+
+      - name: Check token replaced in single value message
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-single-value-token.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported one-and-only value
+
+          EOF
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Use code block for single value
+        uses: ./report-step-result/print-list
+        with:
+          values: single
+          message: Reported values
+          output-file-path: ${{ runner.temp }}/report-code-block-single.txt
+          code-block: true
+
+      - name: Check code block used for single value
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-code-block-single.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported values: `single`
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Print multiple values
+        uses: ./report-step-result/print-list
+        with:
+          values: one two three
+          message: Reported values
+          output-file-path: ${{ runner.temp }}/report-multiple-values.txt
+          code-block: false
+
+      - name: Check multiple values reported
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-multiple-values.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported values:
+            - one
+            - two
+            - three
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]
+
+
+      - name: Use code block for multiple values
+        uses: ./report-step-result/print-list
+        with:
+          values: one two three
+          message: Reported values
+          output-file-path: ${{ runner.temp }}/report-code-block-multiple.txt
+          code-block: true
+
+      - name: Check code block used for multiple values
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/report-code-block-multiple.txt
+        run: |
+          cat << 'EOF' > expected_file
+          Reported values:
+            - `one`
+            - `two`
+            - `three`
+
+          [[ $(cat "$OUTPUT_FILE") == $(cat expected_file) ]]

--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -71,7 +71,7 @@ runs:
     - name: Check image exists
       id: check-image-exists
       if: ${{ inputs.immutable-tags == 'true' && inputs.image-version != null }}
-      uses: alphagov/di-github-actions/aws/ecr/check-image-exists@28a6bf96563343af503eac737bff50d8e93505ff
+      uses: alphagov/di-github-actions/aws/ecr/check-image-exists@525bcf25919855cb5909e2d3c7b341e2e0a0aa6e
       with:
         repository: ${{ inputs.REPOSITORY }}
         image-tags: ${{ inputs.image-version }}
@@ -79,7 +79,7 @@ runs:
     - name: Get previous image version
       id: get-previous-version
       if: ${{ inputs.immutable-tags == 'true' && steps.check-image-exists.outputs.image-exists == 'false' }}
-      uses: alphagov/di-github-actions/aws/ecr/check-image-exists@28a6bf96563343af503eac737bff50d8e93505ff
+      uses: alphagov/di-github-actions/aws/ecr/check-image-exists@525bcf25919855cb5909e2d3c7b341e2e0a0aa6e
       with:
         repository: ${{ inputs.repository }}
         image-tags: ${{ inputs.image-tags }}

--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -147,7 +147,7 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
       run: |
         mapfile -t tags < <(docker image ls "$REGISTRY/$REPOSITORY" --format '{{.Tag}}')
-        mapfile -t digests < <(docker image ls "$REGISTRY/$REPOSITORY" --format '{{.Digest}}' | uniq)
+        mapfile -t digests < <(docker image ls "$REGISTRY/$REPOSITORY" --format '{{.Digest}}' | sort -u)
         
         if [[ ${#digests[@]} -ne 1 ]]; then
           echo "Expected one image digest for image $REGISTRY/$REPOSITORY but got \`${digests[*]}\`"
@@ -155,8 +155,8 @@ runs:
         fi
         
         digest=${digests[*]}
-        [[ ${#tags[@]} -gt 1 ]] && plural=true
-        [[ ${#tags[@]} -gt 0 ]] && tag_msg="tag${plural:+s} \`${tags[*]}\`"
+        [[ ${#tags[@]} -le 1 ]] || plural=true
+        [[ ${#tags[@]} -le 0 ]] || tag_msg="tag${plural:+s} \`${tags[*]}\`"
         
         echo "Pushed image with ${tag_msg:-digest \`$digest\`}" >> "$GITHUB_STEP_SUMMARY"
         echo "image-digest=$digest" >> "$GITHUB_OUTPUT"

--- a/aws/ecr/check-image-exists/action.yml
+++ b/aws/ecr/check-image-exists/action.yml
@@ -18,21 +18,16 @@ runs:
   using: composite
   steps:
     - name: Get image digests
-      id: get-image-digests
-      uses: alphagov/di-github-actions/aws/ecr/get-image-digests@e87b9378ea8cb6a6debdd90eb1097759d79ea919
-      with:
-        repository: ${{ inputs.repository }}
-        image-tags: ${{ inputs.image-tags }}
-
-    - name: Check image exists
       id: check-image-exists
       shell: bash
       env:
+        REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
-        IMAGE_DIGESTS: ${{ steps.get-image-digests.outputs.image-digests }}
+        IMAGE_DIGESTS: ${{ github.action_path }}/../../../scripts/aws/ecr/get-image-digests.sh
       run: |
-        read -ra images <<< "$IMAGE_DIGESTS"
-        
+        image_digests=$($IMAGE_DIGESTS)
+        read -ra images <<< "$image_digests"
+
         if [[ ${#images[@]} -gt 1 ]]; then
           echo "::error::Expected only one image with tags '$IMAGE_TAGS' but got multiple: ${images[*]}"
           exit 1
@@ -50,6 +45,5 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
       run: |
         read -ra tags <<< "$(tr '\n' ' ' <<< "$IMAGE_TAGS")"
-        [[ ${#tags[@]} -gt 1 ]] && plural=s
-        echo "Image with tag${plural:-} \`${tags[*]}\` exists in repository \`$REPOSITORY\`" >> "$GITHUB_STEP_SUMMARY" 
-        cat "$GITHUB_STEP_SUMMARY"
+        [[ ${#tags[@]} -gt 1 ]] && plural=true
+        echo "Image with tag${plural:+s} \`${tags[*]}\` exists in repository \`$REPOSITORY\`" | tee "$GITHUB_STEP_SUMMARY"

--- a/aws/ecr/get-image-digests/action.yml
+++ b/aws/ecr/get-image-digests/action.yml
@@ -20,15 +20,5 @@ runs:
       env:
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
-      run: |
-        read -ra tags <<< "$(tr '\n' ' ' <<< "$IMAGE_TAGS")"
-        tags=("${tags[@]/#/\'}") && tags=("${tags[@]/%/\'}")
-        tag_list=$(IFS=","; echo "[${tags[*]}]")
-        
-        image_list=$(aws ecr list-images \
-          --repository-name "$REPOSITORY" \
-          --query "imageIds[?contains($tag_list, imageTag)].[imageDigest]" \
-          --output text | uniq)
-        
-        mapfile -t images <<< "$image_list"
-        echo "image-digests=${images[*]}" >> "$GITHUB_OUTPUT"
+        IMAGE_DIGESTS: ${{ github.action_path }}/../../../scripts/aws/ecr/get-image-digests.sh
+      run: echo "image-digests=$($IMAGE_DIGESTS)" >> "$GITHUB_OUTPUT"

--- a/aws/ecs/deregister-stale-task-definitions/action.yml
+++ b/aws/ecs/deregister-stale-task-definitions/action.yml
@@ -1,0 +1,39 @@
+name: 'Clean up stale task definitions'
+description: 'Deregister ECS task definitions which point to ECR images that no longer exist'
+inputs:
+  container:
+    description: 'Specifies the container definition containing the image to check, otherwise pick first container'
+    required: false
+  family:
+    description: 'ECS task definition family to clean up'
+    required: false
+  registry:
+    description: 'Registry ID to query for images'
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Clean up stale task definitions
+      id: deregister-task-definitions
+      shell: bash
+      run: ${{ github.action_path }}/deregister-stale-task-definitions.sh
+      env:
+        ECS_FAMILY: ${{ inputs.family }}
+        CONTAINER: ${{ inputs.container }}
+        REGISTRY: ${{ inputs.registry }}
+
+    - name: Report results
+      if: ${{ always() && join(steps.deregister-task-definitions.outputs.*, '') != null }}
+      shell: bash
+      env:
+        DEREGISTERED_DEFINITIONS: ${{ steps.deregister-task-definitions.outputs.deregistered-definitions }}
+        FAILED_DEFINITIONS: ${{ steps.deregister-task-definitions.outputs.failed-definitions }}
+        REPORT: ${{ github.action_path }}/../../../scripts/report-step-result/print-list.sh
+      run: |
+        [[ -z $DEREGISTERED_DEFINITIONS ]] ||
+          VALUES=$DEREGISTERED_DEFINITIONS MESSAGE="Deregistered task definitions" \
+            SINGLE_MESSAGE="Deregistered task definition %s" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"
+        
+        [[ -z $FAILED_DEFINITIONS ]] ||
+          VALUES=$FAILED_DEFINITIONS MESSAGE="Failed to deregister task definitions" \
+            SINGLE_MESSAGE="Failed to deregister task definition %s" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"

--- a/aws/ecs/deregister-stale-task-definitions/deregister-stale-task-definitions.sh
+++ b/aws/ecs/deregister-stale-task-definitions/deregister-stale-task-definitions.sh
@@ -1,0 +1,42 @@
+set -eu
+
+deregistered_definitions=()
+failed_definitions=()
+
+task_definitions=$(aws ecs list-task-definitions \
+  ${ECS_FAMILY:+--family-prefix $ECS_FAMILY} \
+  --status ACTIVE \
+  --query "taskDefinitionArns" \
+  --output text)
+
+read -ra task_definitions <<< "$task_definitions"
+container_query="${CONTAINER:+?name=="'$CONTAINER'"}"
+
+for task_definition in "${task_definitions[@]}"; do
+  image=$(aws ecs describe-task-definition \
+    --task-definition "$task_definition" \
+    --query "taskDefinition.containerDefinitions[${container_query:-0}].image" \
+    --output text)
+
+  image_name="${image#*/}"
+  image_repo="${image_name%:*}"
+  image_tag="${image_name#*:}"
+
+  if ! aws ecr describe-images \
+    ${REGISTRY:+--registry-id $REGISTRY} \
+    --repository-name "$image_repo" \
+    --image-ids imageTag="$image_tag" > /dev/null; then
+
+    task_definition_version="${task_definition#*task-definition/}"
+    echo "Deregistering task definition $task_definition_version..."
+
+    aws ecs deregister-task-definition --task-definition "$task_definition" > /dev/null &&
+      deregistered_definitions+=("$task_definition_version") ||
+      failed_definitions+=("$task_definition_version")
+  fi
+done
+
+echo "deregistered-definitions=${deregistered_definitions[*]}" >> "$GITHUB_OUTPUT"
+echo "failed-definitions=${failed_definitions[*]}" >> "$GITHUB_OUTPUT"
+
+[[ ${#failed_definitions[@]} -eq 0 ]] || exit 1

--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -63,7 +63,7 @@ runs:
         echo "::notice::Running Prettier..."
         read -ra files <<< "$FILES"
         [[ ${#files[@]} -eq 0 ]] && files=(.)
-        npx prettier --check "${files[@]}" 2>&1 | tee "$OUTPUT_FILE"        
+        npx prettier --ignore-unknown --check "${files[@]}" 2>&1 | tee "$OUTPUT_FILE"        
 
     - name: Run ESLint
       id: run-eslint

--- a/paas/delete-stale-apps/action.yml
+++ b/paas/delete-stale-apps/action.yml
@@ -9,7 +9,24 @@ runs:
   using: composite
   steps:
     - name: Clean up stale deployments
+      id: delete-deployments
       run: ${{ github.action_path }}/delete-stale-apps.sh
       shell: bash
       env:
         THRESHOLD_DAYS: ${{ inputs.age-threshold-days }}
+
+    - name: Report results
+      if: ${{ always() && join(steps.delete-deployments.outputs.*, '') != null }}
+      shell: bash
+      env:
+        DELETED_APPS: ${{ steps.delete-deployments.outputs.deleted-apps }}
+        FAILED_APPS: ${{ steps.delete-deployments.outputs.failed-apps }}
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-list.sh
+      run: |
+        [[ -z $DELETED_APPS ]] ||
+          VALUES=$DELETED_APPS MESSAGE="Deleted apps" SINGLE_MESSAGE="Deleted app %s" $REPORT |
+          tee -a "$GITHUB_STEP_SUMMARY"
+
+        [[ -z $FAILED_APPS ]] ||
+          VALUES=$FAILED_APPS MESSAGE="Failed to delete apps" SINGLE_MESSAGE="Failed to delete app %s" $REPORT |
+          tee -a "$GITHUB_STEP_SUMMARY"

--- a/report-step-result/print-list/action.yml
+++ b/report-step-result/print-list/action.yml
@@ -1,0 +1,41 @@
+name: 'Print a list of values to the job summary'
+description: 'Print the specified list to the current job summary with an action message'
+inputs:
+  values:
+    description: 'Values to append to the job summary, space or newline-delimited string'
+    required: true
+  message:
+    description: 'Message to print before the list'
+    required: true
+  single-message:
+    description: 'Message to print when the list contains a single element; use the token %s to insert the value'
+    required: false
+  code-block:
+    description: 'Print the values in a code block'
+    required: false
+    default: 'true'
+  output-file-path:
+    description: 'Override the default destination and write the output to the specified file instead'
+    required: false
+  quiet:
+    description: 'Whether to print the report to the console'
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Print list to step summary
+      shell: bash
+      env:
+        VALUES: ${{ inputs.values }}
+        MESSAGE: ${{ inputs.message }}
+        SINGLE_MESSAGE: ${{ inputs.single-message }}
+        CODE_BLOCK: ${{ inputs.code-block == 'true' }}
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-list.sh
+        OUT_FILE: ${{ inputs.output-file-path }}
+        VERBOSE: ${{ inputs.quiet == 'false' }}
+      run: |
+        output_file=${OUT_FILE:-$GITHUB_STEP_SUMMARY}
+        $REPORT >> "$output_file"
+        $VERBOSE && cat "$output_file"
+        echo "The result has been written to ${OUT_FILE:-the job summary}"

--- a/scripts/aws/ecr/get-image-digests.sh
+++ b/scripts/aws/ecr/get-image-digests.sh
@@ -1,0 +1,20 @@
+set -eu
+
+: "${REPOSITORY}" # ECR repository name
+: "${IMAGE_TAGS}" # Tags associated with the targeted images, delimited by spaces or newlines
+
+read -ra tags <<< "$(tr '\n' ' ' <<< "$IMAGE_TAGS")"
+tags=("${tags[@]/#/\'}") && tags=("${tags[@]/%/\'}")
+
+tag_list=$(
+  IFS=","
+  echo "[${tags[*]}]"
+)
+
+image_list=$(aws ecr list-images \
+  --repository-name "$REPOSITORY" \
+  --query "imageIds[?contains($tag_list, imageTag)].[imageDigest]" \
+  --output text | sort -u)
+
+mapfile -t images <<< "$image_list"
+echo "${images[*]}"

--- a/scripts/report-step-result/print-list.sh
+++ b/scripts/report-step-result/print-list.sh
@@ -1,0 +1,30 @@
+set -eu
+
+: "${VALUES}"           # Values to append to the job summary, space or newline-delimited string
+: "${MESSAGE}"          # Message to print before the list
+: "${SINGLE_MESSAGE:=}" # Message to print when the list contains a single element; use the token %s to insert the value
+: "${CODE_BLOCK:=true}" # Print the values in a code block
+
+$CODE_BLOCK && code_block_char="\`"
+read -ra list <<< "$(tr '\n' ' ' <<< "$VALUES")"
+
+if [[ ${#list[@]} -eq 0 ]]; then
+  echo "No elements to print"
+  exit 1
+fi
+
+if [[ ${#list[@]} -eq 1 ]]; then
+  value="${code_block_char:-}${list[*]}${code_block_char:-}"
+
+  if [[ $SINGLE_MESSAGE =~ %s ]]; then
+    echo "${SINGLE_MESSAGE//%s/$value}"
+  else
+    echo "${SINGLE_MESSAGE:-$MESSAGE}: $value"
+  fi
+else
+  echo "$MESSAGE:"
+  for value in "${list[@]}"; do
+    echo "  - ${code_block_char:-}$value${code_block_char:-}"
+  done
+  echo
+fi


### PR DESCRIPTION
**DFA-2213: Add an action to clean up stale ECS task definitions**

The action deregisters ECS task definitions that reference ECR images that no longer exist in the repository.

---

**Add action to print an array of values**

The action can print a list of values to a file or the step summary.
GitHub Flavored Markdown is used to produce output that can be displayed with formatting in GitHub Actions job summaries.

The script takes an optional message when there's only one element in the list. The script can substitute a token for the single value to print a customised message in that case.

---

**DFA-2213: Fixes to ECR docker actions**

  - Use `sort -u` instead of `uniq` to correctly list uniqe images
  - Move the logic to get image digests into a separate script that can be used in different actions
  - Remove dependency on the `aws/ecr/get-image-digests` action in `aws/ecr/check-image-exists` - use the script instead

---

- Don't print an error message on files that prettier can't parse

  Prettier prints the message "Error: No parser could be inferred for file" when it encounters a file that it's not designed to handle, e.g. `*.json` or `*.feature` files. We can safely ignore those, and we don't need to log the error message.

- Fix failing PaaS cleanup job 

  Don't fail when there are no failed stacks, and correctly report results.