### PR TITLE
BAU: Fix checkov

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Run Checkov
         uses: ./code-quality/run-checkov
+        with:
+          skip-checks: CKV_SECRET_6
 
   check-shell-scripts:
     name: Check shell scripts

--- a/.github/workflows/test-deploy-to-paas.yml
+++ b/.github/workflows/test-deploy-to-paas.yml
@@ -114,9 +114,9 @@ jobs:
       - name: Check correct variable substitution file created
         run: |
           cat << 'EOF' > expected_file
-          memory: unlimited
-          deployment: continuous
           app: test
+          deployment: continuous
+          memory: unlimited
           EOF
           
-          [[ $(cat "$VARS_FILE") == $(cat expected_file) ]]
+          cat "$VARS_FILE" | sort | diff expected_file -

--- a/aws/ecs/deregister-stale-task-definitions/action.yml
+++ b/aws/ecs/deregister-stale-task-definitions/action.yml
@@ -31,9 +31,9 @@ runs:
         REPORT: ${{ github.action_path }}/../../../scripts/report-step-result/print-list.sh
       run: |
         [[ -z $DEREGISTERED_DEFINITIONS ]] ||
-          VALUES=$DEREGISTERED_DEFINITIONS MESSAGE="Deregistered task definitions" \
-            SINGLE_MESSAGE="Deregistered task definition %s" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"
+          VALUES=$DEREGISTERED_DEFINITIONS MESSAGE="Deregistered ECS task definitions" \
+            SINGLE_MESSAGE="Deregistered ECS task definition %s" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"
         
         [[ -z $FAILED_DEFINITIONS ]] ||
-          VALUES=$FAILED_DEFINITIONS MESSAGE="Failed to deregister task definitions" \
-            SINGLE_MESSAGE="Failed to deregister task definition %s" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"
+          VALUES=$FAILED_DEFINITIONS MESSAGE="Failed to deregister ECS task definitions" \
+            SINGLE_MESSAGE="Failed to deregister ECS task definition %s" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"

--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -4,6 +4,12 @@ inputs:
   path:
     description: 'Only run checks on files matching the specified path filter'
     required: false
+  skip-checks:
+    description: "Checks to skip. Multiple values separated by commas, spaces or newlines"
+    required: false
+  skip-frameworks:
+    description: "Frameworks to skip. Multiple values separated by commas, spaces or newlines"
+    required: false
 runs:
   using: composite
   steps:
@@ -34,22 +40,49 @@ runs:
       run: echo "::group::pip output" && pip install checkov && echo "::endgroup::"
       shell: bash
 
-    - name: Run Checkov on a pull request
-      id: run-checkov-pr
+    - name: Parse options
+      id: checkov-options
+      shell: bash
+      env:
+        SKIP_CHECKS: ${{ inputs.skip-checks }}
+        SKIP_FRAMEWORKS: ${{ inputs.skip-frameworks }}
+      run: |
+        if [[ -n $SKIP_CHECKS ]]; then
+          echo "skip-checks=--skip-check $(echo -n "$SKIP_CHECKS" | tr '\n' ' ' | tr ' ' ',')" >> "$GITHUB_OUTPUT"
+        fi
+        
+        if [[ -n $SKIP_FRAMEWORKS ]]; then
+          echo "skip-frameworks=--skip-framework $(echo -n "$SKIP_FRAMEWORKS" | tr '\n' ',' | tr ',' ' ')" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Get pull request files
+      id: get-pr-files
       if: ${{ steps.check-merge-commit.outputs.merging == 'true' }}
       shell: bash
       env:
         DIR: ${{ inputs.path }}
-        OUTPUT_FILE: ${{ runner.temp }}/checkov.output
+        FILES: ${{ runner.temp }}/pr-files
       run: |
         files=$(git diff --name-only --diff-filter=d HEAD^...HEAD)
         [[ $DIR ]] && files=$(grep "$DIR" <<< "$files" || true)
-        
-        if [[ $files ]]; then
-          mapfile -t files <<< "$files"
-          read -ra files <<< "${files[@]/#/-f }"
-          checkov --quiet --skip-framework secrets "${files[@]}" | tee "$OUTPUT_FILE"
+        if [[ -n $files ]]; then
+          echo "$files" >> "$FILES"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
         fi
+
+    - name: Run Checkov on a pull request
+      id: run-checkov-pr
+      if: ${{ steps.check-merge-commit.outputs.merging == 'true' && steps.get-pr-files.outputs.files != null }}
+      shell: bash
+      env:
+        FILES: ${{ steps.get-pr-files.outputs.files }}
+        SKIP_CHECKS: ${{ steps.checkov-options.outputs.skip-checks }}
+        SKIP_FRAMEWORKS: ${{ steps.checkov-options.outputs.skip-frameworks }}
+        OUTPUT_FILE: ${{ runner.temp }}/checkov.output
+      run: |
+        mapfile -t files < "$FILES"
+        read -ra files <<< "${files[@]/#/-f }"  
+        checkov --quiet "${files[@]}" ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee "$OUTPUT_FILE"
 
     - name: Run Checkov on a directory
       id: run-checkov-dir
@@ -57,18 +90,22 @@ runs:
       shell: bash
       env:
         DIR: ${{ inputs.path }}
+        SKIP_CHECKS: ${{ steps.checkov-options.outputs.skip-checks }}
+        SKIP_FRAMEWORKS: ${{ steps.checkov-options.outputs.skip-frameworks }}
         OUTPUT_FILE: ${{ runner.temp }}/checkov.output
-      run: checkov --quiet -d "$DIR" | tee "$OUTPUT_FILE"
+      run: checkov --quiet -d "$DIR" ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee "$OUTPUT_FILE"
 
     - name: Run Checkov on the repo
       id: run-checkov-repo
       if: ${{ steps.check-merge-commit.outputs.merging == 'false' && inputs.path == null }}
       shell: bash
       env:
+        SKIP_CHECKS: ${{ steps.checkov-options.outputs.skip-checks }}
+        SKIP_FRAMEWORKS: ${{ steps.checkov-options.outputs.skip-frameworks }}
         OUTPUT_FILE: ${{ runner.temp }}/checkov.output
       run: |
-        checkov --quiet -d . | tee "$OUTPUT_FILE"
-        [[ -d .github ]] && checkov --quiet -d .github | tee -a "$OUTPUT_FILE"
+        checkov --quiet -d . ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee "$OUTPUT_FILE"
+        [[ -d .github ]] && checkov --quiet -d .github ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee -a "$OUTPUT_FILE"
 
     - name: Report Checkov result
       if: ${{ failure() }}

--- a/sam/check-stacks-exist/action.yml
+++ b/sam/check-stacks-exist/action.yml
@@ -1,4 +1,4 @@
-name: 'Check SAM stack exists'
+name: 'Check SAM stacks exist'
 description: 'Checks whether the specified AWS SAM stack exists using the AWS credentials configured in the job'
 inputs:
   stack-names:
@@ -18,11 +18,29 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Check stack exists
+    - name: Check stacks exist
       id: check-stacks-exist
       run: ${{ github.action_path }}/check-stacks-exist.sh
       shell: bash
       env:
         STACK_NAMES: ${{ inputs.stack-names }}
         SET_ENV_VAR: ${{ inputs.set-env-var }}
+
+    - name: Report results
+      if: ${{ join(steps.check-stacks-exist.outputs.*, '') != null }}
+      shell: bash
+      env:
+        EXISTING_STACKS: ${{ steps.check-stacks-exist.outputs.existing-stacks }}
+        MISSING_STACKS: ${{ steps.check-stacks-exist.outputs.missing-stacks }}
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-list.sh
         VERBOSE: ${{ inputs.verbose == 'true' }}
+      run: |
+        $VERBOSE && step_summary=$GITHUB_STEP_SUMMARY
+        
+        [[ -z $EXISTING_STACKS ]] ||
+          VALUES=$EXISTING_STACKS MESSAGE="Existing stacks" SINGLE_MESSAGE="Stack %s exists" $REPORT |
+          tee "${step_summary:-}"
+        
+        [[ -z $MISSING_STACKS ]] ||
+          VALUES=$MISSING_STACKS MESSAGE="Non-existent stacks" SINGLE_MESSAGE="Stack %s does not exist" $REPORT |
+          tee "${step_summary:-}"

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -24,10 +24,27 @@ runs:
         verbose: true
 
     - name: Delete stacks
-      if: ${{ steps.check-stacks-exist.outputs.existing-stacks }}
+      id: delete-stacks
+      if: ${{ steps.check-stacks-exist.outputs.existing-stacks != null }}
       run: ${{ github.action_path }}/delete-stacks.sh
       shell: bash
       env:
         STACK_NAMES: ${{ steps.check-stacks-exist.outputs.existing-stacks }}
         ONLY_FAILED: ${{ inputs.only-if-failed == 'true' }}
         AWS_REGION: ${{ inputs.aws-region }}
+
+    - name: Report results
+      if: ${{ always() && join(steps.delete-stacks.outputs.*, '') != null }}
+      shell: bash
+      env:
+        DELETED_STACKS: ${{ steps.delete-stacks.outputs.deleted-stacks }}
+        FAILED_STACKS: ${{ steps.delete-stacks.outputs.failed-stacks }}
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-list.sh
+      run: |
+        [[ -z $DELETED_STACKS ]] ||
+          VALUES=$DELETED_STACKS MESSAGE="Deleted stacks" SINGLE_MESSAGE="Deleted stack %s" $REPORT |
+          tee "$GITHUB_STEP_SUMMARY"
+        
+        [[ -z $FAILED_STACKS ]] ||
+          VALUES=$FAILED_STACKS MESSAGE="Failed to delete stacks" SINGLE_MESSAGE="Failed to delete stack %s" $REPORT |
+          tee "$GITHUB_STEP_SUMMARY"

--- a/sam/delete-stacks/delete-stacks.sh
+++ b/sam/delete-stacks/delete-stacks.sh
@@ -3,17 +3,18 @@ set -eu
 region=${AWS_REGION}
 delete_only_failed=${ONLY_FAILED}
 
-read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
-
 deleted_stacks=()
 failed_stacks=()
+
+read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
+
 for stack in "${stacks[@]}"; do
   if $delete_only_failed; then
     stack_info=$(aws cloudformation describe-stacks --stack-name "$stack")
     stack_state=$(jq -r '.Stacks[].StackStatus' <<< "$stack_info")
 
     if ! [[ $stack_state =~ FAILED ]]; then
-      echo "Stack $stack is in a good state: $stack_state - not deleting"
+      echo "Stack '$stack' is in a good state: '$stack_state' - not deleting"
       continue
     fi
   fi
@@ -21,22 +22,7 @@ for stack in "${stacks[@]}"; do
   sam delete --no-prompts --region "$region" --stack-name "$stack" && deleted_stacks+=("$stack") || failed_stacks+=("$stack")
 done
 
-if [[ ${#deleted_stacks[@]} -eq 1 ]]; then
-  echo "Deleted stack \`${deleted_stacks[*]}\`" >> "$GITHUB_STEP_SUMMARY"
-elif [[ ${#deleted_stacks[@]} -gt 1 ]]; then
-  echo "Deleted stacks:" >> "$GITHUB_STEP_SUMMARY"
-  for stack in "${deleted_stacks[@]}"; do
-    echo "  - $stack" >> "$GITHUB_STEP_SUMMARY"
-  done
-fi
+echo "deleted-stacks=${deleted_stacks[*]}" >> "$GITHUB_OUTPUT"
+echo "failed-stacks=${failed_stacks[*]}" >> "$GITHUB_OUTPUT"
 
-if [[ ${#failed_stacks[@]} -eq 1 ]]; then
-  echo "Failed to delete stack \`${failed_stacks[*]}\`" >> "$GITHUB_STEP_SUMMARY"
-elif [[ ${#failed_stacks[@]} -gt 1 ]]; then
-  echo "Failed to delete stacks:" >> "$GITHUB_STEP_SUMMARY"
-  for stack in "${failed_stacks[@]}"; do
-    echo "  - $stack" >> "$GITHUB_STEP_SUMMARY"
-  done
-fi
-
-cat "$GITHUB_STEP_SUMMARY"
+[[ ${#failed_stacks[@]} -eq 0 ]] || exit 1

--- a/sam/get-stale-stacks/action.yml
+++ b/sam/get-stale-stacks/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   stack-tag-filters:
     description: 'Filter stacks by tags, encoded as name=value pairs separated by newlines or "|"'
-    required: false
+    required: true
   env-var-name:
     description: 'Accumulate stack names in the environment variable with the specified name, persisted in the job'
     required: false
@@ -40,4 +40,15 @@ runs:
         STACK_NAME_FILTER: ${{ inputs.stack-name-filter }}
         STACK_TAG_FILTERS: ${{ steps.parse-tag-filters.outputs.parsed-parameters }}
         ENV_VAR_NAME: ${{ inputs.env-var-name }}
-        STACKS_DESCRIPTION: ${{ inputs.description }}
+
+    - name: Report results
+      shell: bash
+      env:
+        DESCRIPTION: ${{ inputs.description }}
+        VALUES: ${{ steps.filter-stacks.outputs.stack-names }}
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-list.sh
+      run: |
+        ([[ $VALUES ]] &&
+          MESSAGE="Stale ${DESCRIPTION:+$DESCRIPTION }stacks" $REPORT ||
+          echo "There are no stale ${DESCRIPTION:+$DESCRIPTION }stacks") |
+          tee "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
**Fix checkov**
checkov errors if no checks are enabled since version `2.2.150`
This was happening since the action by default excluded the security framework so if there were no IaC (infrastructure as code) files in a PR, then no other frameworks would be enabled (e.g. CloudFormation) and the run would fail.
Instead, don't exclude the framework by default and add options to exclude specific frameworks and checks, as needed.

**Use the print list script to report job results** 
  Use the `scripts/report-step-result/print-list.sh` script to report results instead of duplicating the logic across multiple scripts.

---

- Fix test failing due to random order of evaluating variables 
   Sort the output file so we always get the same order