### PR TITLE
SSE-2463: Add npm audit action and run cfn-lint

### DIFF
--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -21,6 +21,7 @@ runs:
   using: composite
   steps:
     - name: Check if merge commit
+      id: check-merge-commit
       shell: bash
       env:
         EVENT: ${{ github.event_name }}
@@ -63,8 +64,8 @@ runs:
       if: ${{ env.MERGING == 'true' }}
       shell: bash
       run: |
-        mapfile -t files < <(git diff --name-only --diff-filter=d HEAD^...HEAD)
-        echo "FILES=${files[*]}" >> "$GITHUB_ENV"
+        files=$(git diff --name-only --diff-filter=d HEAD^...HEAD | tr '\n' ' ')
+        echo "FILES=$files" >> "$GITHUB_ENV"
 
     - name: Run Prettier
       if: ${{ inputs.run-prettier == 'true' && (env.FILES != null || env.MERGING == 'false') }}
@@ -77,7 +78,7 @@ runs:
         $MERGING && read -ra files <<< "$FILES" || files=(.)
         
         npx prettier --ignore-unknown --check "${files[@]}" 2>&1 | tee "$OUTPUT" ||
-          FILE=$OUTPUT TITLE=Prettier CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY"
+          (FILE=$OUTPUT TITLE=Prettier CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY" && exit 1)
 
     - name: Run ESLint
       if: ${{ always() && inputs.run-eslint == 'true' && (env.FILES != null || env.MERGING == 'false') }}
@@ -97,16 +98,14 @@ runs:
           read -ra types <<< "$(tr '\n' ' ' <<< "$TYPES")"
           filetype_regex="$(IFS="|"; echo ".*\.(${types[*]##.})$")"
         
-          if filtered_files="$(grep -E --regexp="$filetype_regex" <<< "$files")"; then
-            mapfile -t es_files <<< "$filtered_files"
-          else
-            echo "No files to check"
-            exit 0
-          fi
+          filtered_files="$(grep -E --regexp="$filetype_regex" <<< "$files")" ||
+            (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+        
+          mapfile -t es_files <<< "$filtered_files"
         fi
         
-        npx eslint "${max_warnings:-}" "${es_files[@]}" | tee "$OUTPUT" ||
-          FILE=$OUTPUT TITLE=ESLint CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY"
+        npx eslint ${max_warnings:-} "${es_files[@]}" | tee "$OUTPUT" ||
+          (FILE=$OUTPUT TITLE=ESLint CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY" && exit 1)
 
     - name: Run cfn-lint
       if: ${{ always() && inputs.run-cfn-lint == 'true' && (env.FILES != null || env.MERGING == 'false') }}

--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether to run ESLint'
     required: false
     default: 'true'
+  run-cfn-lint:
+    description: 'Whether to run AWS CloudFormation Linter'
+    required: false
+    default: 'true'
   error-on-warnings:
     description: 'Treat warnings as errors'
     required: false
@@ -31,15 +35,28 @@ runs:
         fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
 
     - name: Set up Node
+      if: ${{ inputs.run-prettier == 'true' || inputs.run-eslint == 'true' }}
       uses: actions/setup-node@v3
       with:
         cache: npm
 
+    - name: Set up Python
+      if: ${{ inputs.run-cfn-lint == 'true' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+        cache-dependency-path: ./.github/workflows
+        cache: pip
+
     - name: Install linting tools
       shell: bash
+      env:
+        NODE_TOOLS: ${{ inputs.run-prettier == 'true' || inputs.run-eslint == 'true' }}
+        PYTHON_TOOLS: ${{ inputs.run-cfn-lint == 'true' }}
       run: |
         echo "::group::Install packages"
-        npm install prettier eslint
+        $NODE_TOOLS && npm install prettier eslint
+        $PYTHON_TOOLS && pip install cfn-lint
         echo "::endgroup::"
 
     - name: Get files to check
@@ -90,3 +107,29 @@ runs:
         
         npx eslint "${max_warnings:-}" "${es_files[@]}" | tee "$OUTPUT" ||
           FILE=$OUTPUT TITLE=ESLint CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Run cfn-lint
+      if: ${{ always() && inputs.run-cfn-lint == 'true' && (env.FILES != null || env.MERGING == 'false') }}
+      shell: bash
+      env:
+        STRICT: ${{ inputs.error-on-warnings == 'true' }}
+        OUTPUT: ${{ runner.temp }}/cfn-lint.output
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-file.sh
+      run: |
+        echo ":: Running cfn-lint"
+        $STRICT && error_on_warnings=true
+        
+        if $MERGING; then
+          files="$FILES"
+        else
+          shopt -s globstar dotglob extglob nullglob
+          files=$(echo !(.github|node_modules|.aws-sam)/!(node_modules|.aws-sam)/*.@(yaml|yml))
+        fi
+        
+        read -ra files <<< "$files"
+        filtered_files=$(grep -El --regexp='^AWSTemplateFormatVersion: "?[[:digit:]-]+"?' "${files[@]}") ||
+          (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+        
+        mapfile -t files <<< "$filtered_files"
+        cfn-lint ${error_on_warnings:+--non-zero-exit-code warning} "${files[@]}" | tee "$OUTPUT" ||
+          (FILE=$OUTPUT TITLE="CloudFormation linter" CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY" && exit 1)

--- a/code-quality/check-shell-scripts/action.yml
+++ b/code-quality/check-shell-scripts/action.yml
@@ -52,8 +52,11 @@ runs:
         if $MERGING; then
           files=$(git diff --name-only --diff-filter=d HEAD^...HEAD)
           filetype_regex="$(IFS="|"; echo ".*\.(${types[*]##.})$")"
-          mapfile -t files < <(grep -E --regexp="$filetype_regex" <<< "$files")
-          scripts="${files[*]}"
+
+          filtered_files=$(grep -E --regexp="$filetype_regex" <<< "$files") ||
+            (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+
+          scripts=$(tr '\n' ' ' <<< "$filtered_files")
         else
           shopt -s globstar dotglob extglob nullglob
           scripts=$(IFS="|"; eval echo "**/*@(${types[*]})")
@@ -72,7 +75,7 @@ runs:
         echo ":: Running shellcheck"
         read -ra scripts <<< "$SCRIPTS"
         shellcheck ${DIALECT:+--shell=$DIALECT} "${scripts[@]}" | tee "$OUTPUT" ||
-          FILE=$OUTPUT TITLE=Shellcheck LANGUAGE=shell $REPORT >> "$GITHUB_STEP_SUMMARY"
+          (FILE=$OUTPUT TITLE=Shellcheck LANGUAGE=shell $REPORT >> "$GITHUB_STEP_SUMMARY" && exit 1)
 
     - name: Run shfmt
       if: ${{ always() && env.SCRIPTS != null && inputs.run-shfmt == 'true' }}
@@ -84,4 +87,4 @@ runs:
         echo ":: Running shfmt"
         read -ra scripts <<< "$SCRIPTS"
         shfmt -d -sr -i 2 "${scripts[@]}" | tee "$OUTPUT" ||
-          FILE=$OUTPUT TITLE="Shell formatting" LANGUAGE=diff $REPORT >> "$GITHUB_STEP_SUMMARY"
+          (FILE=$OUTPUT TITLE="Shell formatting" LANGUAGE=diff $REPORT >> "$GITHUB_STEP_SUMMARY" && exit 1)

--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -61,15 +61,13 @@ runs:
       shell: bash
       env:
         DIR: ${{ inputs.path }}
-        FILES: ${{ runner.temp }}/pr-files
       run: |
         files=$(git diff --name-only --diff-filter=d HEAD^...HEAD)
-        [[ -z $DIR ]] || files=$(grep -E --regexp="^.*\/${DIR}\/.*$" <<< "$files") || true
         
-        if [[ -n $files ]]; then
-          echo "$files" >> "$FILES"
-          echo "files=$FILES" >> "$GITHUB_OUTPUT"
-        fi
+        [[ -z $DIR ]] || files=$(grep -E --regexp="^.*\/${DIR}\/.*$" <<< "$files") ||
+          (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+        
+        echo "files=$(tr '\n' ' ' <<< "$files")" >> "$GITHUB_OUTPUT"
 
     - name: Run Checkov on a pull request
       if: ${{ steps.check-merge-commit.outputs.merging == 'true' && steps.get-pr-files.outputs.files != null }}
@@ -80,9 +78,11 @@ runs:
         SKIP_FRAMEWORKS: ${{ steps.checkov-options.outputs.skip-frameworks }}
         OUTPUT_FILE: ${{ runner.temp }}/checkov.output
       run: |
-        mapfile -t files < "$FILES"
-        read -ra files <<< "${files[@]/#/-f }"  
-        checkov --quiet "${files[@]}" ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee "$OUTPUT_FILE"
+        read -ra files <<< "$FILES"
+        read -ra files <<< "${files[@]/#/-f }"
+        read -ra skip_checks <<< "$SKIP_CHECKS"
+        read -ra skip_frameworks <<< "$SKIP_FRAMEWORKS"
+        checkov --quiet "${files[@]}" "${skip_checks[@]}" "${skip_frameworks[@]}" | tee "$OUTPUT_FILE"
 
     - name: Run Checkov on a directory
       if: ${{ steps.check-merge-commit.outputs.merging == 'false' && inputs.path != null }}
@@ -92,7 +92,10 @@ runs:
         SKIP_CHECKS: ${{ steps.checkov-options.outputs.skip-checks }}
         SKIP_FRAMEWORKS: ${{ steps.checkov-options.outputs.skip-frameworks }}
         OUTPUT_FILE: ${{ runner.temp }}/checkov.output
-      run: checkov --quiet -d "$DIR" ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee "$OUTPUT_FILE"
+      run: |
+        read -ra skip_checks <<< "$SKIP_CHECKS"
+        read -ra skip_frameworks <<< "$SKIP_FRAMEWORKS"
+        checkov --quiet -d "$DIR" "${skip_checks[@]}" "${skip_frameworks[@]}" | tee "$OUTPUT_FILE"
 
     - name: Run Checkov on the repo
       if: ${{ steps.check-merge-commit.outputs.merging == 'false' && inputs.path == null }}
@@ -102,8 +105,10 @@ runs:
         SKIP_FRAMEWORKS: ${{ steps.checkov-options.outputs.skip-frameworks }}
         OUTPUT_FILE: ${{ runner.temp }}/checkov.output
       run: |
-        checkov --quiet -d . ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee -a "$OUTPUT_FILE"
-        [[ -d .github ]] && checkov --quiet -d .github ${SKIP_CHECKS:-} ${SKIP_FRAMEWORKS:-} | tee -a "$OUTPUT_FILE"
+        read -ra skip_checks <<< "$SKIP_CHECKS"
+        read -ra skip_frameworks <<< "$SKIP_FRAMEWORKS"
+        checkov --quiet -d . "${skip_checks[@]}" "${skip_frameworks[@]}" | tee -a "$OUTPUT_FILE"
+        [[ -d .github ]] && checkov --quiet -d .github "${skip_checks[@]}" "${skip_frameworks[@]}" | tee -a "$OUTPUT_FILE"
 
     - name: Report Checkov result
       if: ${{ failure() }}

--- a/code-quality/run-security-audit/action.yml
+++ b/code-quality/run-security-audit/action.yml
@@ -1,0 +1,31 @@
+name: 'Run npm security audit'
+description: 'Run an npm security audit and report results to the job summary if there are vulnerabilities detected'
+inputs:
+  error-if-vulnerabilities:
+    description: 'Exit the job with an error status code if vulnerabilities have been detected'
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Pull repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: ${{ steps.check-merge-commit.outputs.fetch-depth }}
+
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        cache: npm
+
+    - name: Run npm audit
+      shell: bash
+      env:
+        QUIET: ${{ inputs.error-if-vulnerabilities == 'false' }}
+        OUTPUT: ${{ runner.temp }}/npm.output
+        REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-file.sh
+      run: |
+        if ! npm audit --workspaces --include-workspace-root | tee "$OUTPUT"; then
+          FILE=$OUTPUT TITLE="Security audit" CODE_BLOCK=true $REPORT >> "$GITHUB_STEP_SUMMARY"
+          $QUIET || exit 1
+        fi


### PR DESCRIPTION
- Add an action to run npm security audit on a repository
- Add a step to run the AWS CloudFormation linter in the check linting action

- Correctly exit with an error status code when linting checks fail

  The report action runs in a subshell and masks the pipe status. If a check fails, the script needs to explicitly exit with a non-zero code so the failure can surface up to the GitHub Actions interface.

- Correctly handle grep's non-zero exit status - 1 means no files found, otherwise exit with the error code returned