### PR TITLE
SSE-2463: Improvements and additions to ECR/docker actions

### DIFF
--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -1,35 +1,35 @@
-name: 'Build Docker image'
-description: 'Build and push a Docker image to an ECR repo'
+name: "Build Docker image"
+description: "Build and push a Docker image to an ECR repo"
 inputs:
   aws-role-arn:
-    description: 'ARN of AWS role to assume when authenticating to ECR'
+    description: "ARN of AWS role to assume when authenticating to ECR"
     required: false
   aws-region:
-    description: 'AWS region to use'
+    description: "AWS region to use"
     required: false
     default: eu-west-2
   aws-session-name:
-    description: 'Override the default AWS session name'
+    description: "Override the default AWS session name"
     required: false
   registry:
-    description: 'Registry which contains the specified repository'
+    description: "Registry which contains the specified repository"
     required: false
   repository:
-    description: 'ECR repository name'
+    description: "ECR repository name"
     required: true
   image-version:
-    description: 'A unique version identifier to be used as an image tag'
+    description: "A unique version identifier to be used as an image tag"
     required: false
     default: latest
   image-tags:
-    description: 'A list list additional tags to apply to the image, delimited by spaces or newlines'
+    description: "A list list additional tags to apply to the image, delimited by spaces or newlines"
     required: false
   immutable-tags:
-    description: 'Whether the repository is immutable (tags cannot be overwritten)'
+    description: "Whether the repository is immutable (tags cannot be overwritten)"
     required: false
-    default: 'true'
+    default: "true"
   dockerfile-path:
-    description: 'Path to the Dockerfile to use'
+    description: "Path to the Dockerfile to use"
     required: false
   build-path:
     description: "Path to the directory to build"
@@ -51,6 +51,9 @@ outputs:
   image-tags:
     description: "Pass through the additional tags applied to the Docker image"
     value: ${{ inputs.image-tags }}
+  image-uri:
+    description: "Image URI in the format <registry>/<repository>@<digest>"
+    value: ${{ steps.set-image-uri.outputs.image-uri }}
 runs:
   using: composite
   steps:
@@ -70,38 +73,41 @@ runs:
     - name: Check image exists
       id: check-image-exists
       if: ${{ inputs.immutable-tags == 'true' && inputs.image-version != null }}
-      uses: alphagov/di-github-actions/aws/ecr/check-image-exists@525bcf25919855cb5909e2d3c7b341e2e0a0aa6e
-      with:
-        repository: ${{ inputs.REPOSITORY }}
-        image-tags: ${{ inputs.image-version }}
-
-    - name: Get previous image version
-      id: get-previous-version
-      if: ${{ inputs.immutable-tags == 'true' && steps.check-image-exists.outputs.image-exists == 'false' }}
-      uses: alphagov/di-github-actions/aws/ecr/check-image-exists@525bcf25919855cb5909e2d3c7b341e2e0a0aa6e
-      with:
-        repository: ${{ inputs.repository }}
-        image-tags: ${{ inputs.image-tags }}
-
-    - name: Delete previous image version
-      if: ${{ inputs.immutable-tags == 'true' && steps.get-previous-version.outputs.image-exists == 'true' }}
       shell: bash
       env:
         REPOSITORY: ${{ inputs.repository }}
-        IMAGE_DIGEST: ${{ steps.get-previous-version.outputs.image-digest }}
+        IMAGE_TAGS: ${{ inputs.image-version }}
+        CHECK_IMAGE: ${{ github.action_path }}/../../../scripts/aws/ecr/check-image-exists.sh
+      run: |
+        image_digest=$($CHECK_IMAGE)
+        echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"
+
+    - name: Delete previous image version
+      if: ${{ inputs.immutable-tags == 'true' && steps.check-image-exists.outputs.image-digest == null }}
+      shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        IMAGE_TAGS: ${{ inputs.image-tags }}
+        CHECK_IMAGE: ${{ github.action_path }}/../../../scripts/aws/ecr/check-image-exists.sh
         REPORT: ${{ github.action_path }}/../../../scripts/report-step-result/print-file.sh
         TITLE: Deleted previous image version
         LANGUAGE: shell
       run: |
+        image_digest=$($CHECK_IMAGE)
+        if ! [[ $image_digest ]]; then
+          echo "Previous version of image with tags '$IMAGE_TAGS' not found"
+          exit
+        fi
+        
         echo "Deleting previous image version..."
         aws ecr batch-delete-image \
           --repository-name "$REPOSITORY" \
-          --image-ids imageDigest="$IMAGE_DIGEST" \
+          --image-ids imageDigest="$image_digest" \
           --output text | $REPORT | tee "$GITHUB_STEP_SUMMARY" 
 
     - name: Build Docker image
       id: build-image
-      if: ${{ steps.check-image-exists.outputs.image-exists == 'false' }}
+      if: ${{ steps.check-image-exists.outputs.image-digest == null }}
       shell: bash
       env:
         REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
@@ -142,7 +148,7 @@ runs:
         mapfile -t digests < <(docker image ls "$REGISTRY/$REPOSITORY" --format '{{.Digest}}' | sort -u)
         
         if [[ ${#digests[@]} -ne 1 ]]; then
-          echo "Expected one image digest for image $REGISTRY/$REPOSITORY but got \`${digests[*]}\`"
+          echo "Expected one image digest for image \`$REGISTRY/$REPOSITORY\` but got \`${digests[*]}\`"
           exit 1
         fi
         
@@ -150,5 +156,14 @@ runs:
         [[ ${#tags[@]} -le 1 ]] || plural=true
         [[ ${#tags[@]} -le 0 ]] || tag_msg="tag${plural:+s} \`${tags[*]}\`"
         
-        echo "Pushed image with ${tag_msg:-digest \`$digest\`}" >> "$GITHUB_STEP_SUMMARY"
+        echo "Pushed image with ${tag_msg:-digest \`$digest\`} to repository \`$REPOSITORY\`" >> "$GITHUB_STEP_SUMMARY"
         echo "image-digest=$digest" >> "$GITHUB_OUTPUT"
+
+    - name: Set image URI
+      id: set-image-uri
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
+        REPOSITORY: ${{ inputs.repository }}
+        IMAGE_DIGEST: ${{ steps.check-image-exists.outputs.image-digest || steps.report-pushed-image.outputs.image-digest }}
+      run: echo "image-uri=${REGISTRY}/${REPOSITORY}:@${IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"

--- a/aws/ecr/check-image-exists/action.yml
+++ b/aws/ecr/check-image-exists/action.yml
@@ -1,49 +1,30 @@
-name: 'Check image exists'
-description: 'Check if the image with the specified tags exists in the queried ECR repo'
+name: "Check image exists"
+description: "Check if the image with the specified tags exists in the queried ECR repo"
 inputs:
   repository:
-    description: 'ECR repository name'
+    description: "ECR repository name"
     required: true
   image-tags:
-    description: 'Tags associated with the targeted image, delimited by spaces or newlines'
+    description: "Tags associated with the targeted image, delimited by spaces or newlines"
     required: true
 outputs:
   image-exists:
-    description: 'Boolean indicating whether the image exists'
+    description: "Boolean indicating whether the image exists"
     value: ${{ steps.check-image-exists.outputs.image-exists }}
   image-digest:
-    description: 'Digest of the image if it exists'
+    description: "Digest of the image if it exists"
     value: ${{ steps.check-image-exists.outputs.image-digest }}
 runs:
   using: composite
   steps:
-    - name: Get image digests
-      id: check-image-exists
+    - name: Check image exists
       shell: bash
       env:
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
-        IMAGE_DIGESTS: ${{ github.action_path }}/../../../scripts/aws/ecr/get-image-digests.sh
+        CHECK_IMAGE: ${{ github.action_path }}/../../../scripts/aws/ecr/check-image-exists.sh
       run: |
-        image_digests=$($IMAGE_DIGESTS)
-        read -ra images <<< "$image_digests"
-
-        if [[ ${#images[@]} -gt 1 ]]; then
-          echo "::error::Expected only one image with tags '$IMAGE_TAGS' but got multiple: ${images[*]}"
-          exit 1
-        fi
-        
-        [[ ${#images[@]} -eq 1 ]] && image_exists=true || image_exists=false
+        image_digest=$($CHECK_IMAGE)
+        [[ $image_digest ]] && image_exists=true || image_exists=false
         echo "image-exists=$image_exists" >> "$GITHUB_OUTPUT"
-        echo "image-digest=${images[*]}" >> "$GITHUB_OUTPUT"
-
-    - name: Report result
-      if: ${{ steps.check-image-exists.outputs.image-exists == 'true' }}
-      shell: bash
-      env:
-        IMAGE_TAGS: ${{ inputs.image-tags }}
-        REPOSITORY: ${{ inputs.repository }}
-      run: |
-        read -ra tags <<< "$(tr '\n' ' ' <<< "$IMAGE_TAGS")"
-        [[ ${#tags[@]} -gt 1 ]] && plural=true
-        echo "Image with tag${plural:+s} \`${tags[*]}\` exists in repository \`$REPOSITORY\`" | tee "$GITHUB_STEP_SUMMARY"
+        echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"

--- a/aws/ecs/deregister-stale-task-definitions/action.yml
+++ b/aws/ecs/deregister-stale-task-definitions/action.yml
@@ -1,18 +1,41 @@
-name: 'Clean up stale task definitions'
-description: 'Deregister ECS task definitions which point to ECR images that no longer exist'
+name: "Clean up stale task definitions"
+description: "Deregister ECS task definitions which point to ECR images that no longer exist"
 inputs:
+  aws-role-arn:
+    description: "ARN of AWS role to assume when authenticating to ECR"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
+  aws-session-name:
+    description: "Override the default AWS session name"
+    required: false
   container:
-    description: 'Specifies the container definition containing the image to check, otherwise pick first container'
+    description: "Specifies the container definition containing the image to check, otherwise pick the first container"
     required: false
   family:
-    description: 'ECS task definition family to clean up'
+    description: "ECS task definition family to clean up"
     required: false
   registry:
-    description: 'Registry ID to query for images'
+    description: "Registry ID to query for images"
     required: false
 runs:
   using: composite
   steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn != null }}
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        role-session-name: ${{ inputs.aws-session-name }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Login to ECR
+      if: ${{ inputs.registry == null }}
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
     - name: Clean up stale task definitions
       id: deregister-task-definitions
       shell: bash
@@ -20,7 +43,7 @@ runs:
       env:
         ECS_FAMILY: ${{ inputs.family }}
         CONTAINER: ${{ inputs.container }}
-        REGISTRY: ${{ inputs.registry }}
+        REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}
 
     - name: Report results
       if: ${{ always() && join(steps.deregister-task-definitions.outputs.*, '') != null }}

--- a/aws/ecs/deregister-stale-task-definitions/deregister-stale-task-definitions.sh
+++ b/aws/ecs/deregister-stale-task-definitions/deregister-stale-task-definitions.sh
@@ -1,5 +1,9 @@
 set -eu
 
+: "${ECS_FAMILY}"
+: "${CONTAINER}"
+: "${REGISTRY:-}"
+
 deregistered_definitions=()
 failed_definitions=()
 

--- a/aws/ecs/register-task-definition/action.yml
+++ b/aws/ecs/register-task-definition/action.yml
@@ -1,0 +1,95 @@
+name: "Register ECS task definition"
+description: "Render and register an ECS task definition from a json file for an ECR image"
+inputs:
+  aws-role-arn:
+    description: "ARN of AWS role to assume when authenticating to ECR"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
+  aws-session-name:
+    description: "Override the default AWS session name"
+    required: false
+  task-definition:
+    description: "The path to the ECS task definition json file"
+    required: true
+  container:
+    description: "The name of the container defined in the containerDefinitions section of the ECS task definition"
+    required: true
+  image-uri:
+    description: "The URI of the container image to insert into the ECS task definition"
+    required: true
+  environment-variables:
+    description: "Variables to add to the container specified as KEY=value pairs, separated by newlines"
+    required: false
+  task-definition-tags:
+    description: "A list of tags to apply to the registered task definition, key=value pairs separated by newlines or '|'"
+    required: false
+  task-role-arn:
+    description: "Short name or ARN of the role that containers in the registered task can assume"
+    required: false
+  execution-role-arn:
+    description: "Short name or ARN of the role that grants the ECS container agent permissions to make AWS API calls"
+    required: false
+outputs:
+  task-definition-arn:
+    description: "The ARN of the registered task definition"
+    value: ${{ steps.register-task-definition.outputs.task-definition-arn }}
+runs:
+  using: composite
+  steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn != null }}
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        role-session-name: ${{ inputs.aws-session-name }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Login to ECR
+      if: ${{ inputs.registry == null }}
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Parse task definition tags
+      id: parse-tags
+      shell: bash
+      env:
+        PARAMETERS: ${{ inputs.task-definition-tags }}
+        LONG_FORMAT: "true"
+        PARSE: ${{ github.action_path }}/../../../scripts/parse-parameters.sh
+      run: echo "tags=$($PARSE)" >> "$GITHUB_OUTPUT"
+
+    - name: Render task definition
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        environment-variables: ${{ inputs.environment-variables }}
+        task-definition: ${{ inputs.task-definition }}
+        container-name: ${{ inputs.container }}
+        image: ${{ inputs.image-uri }}
+
+    - name: Register task definition
+      id: register-task-definition
+      shell: bash
+      env:
+        TASK_DEFINITION_TEMPLATE: ${{ steps.render-task-definition.outputs.task-definition }}
+        EXECUTION_ROLE_ARN: ${{ inputs.execution-role-arn }}
+        TASK_ROLE_ARN: ${{ inputs.task-role-arn }}
+        IMAGE_URI: ${{ inputs.image-uri }}
+        TAGS: ${{ steps.parse-tags.outputs.tags }}
+      run: |
+        read -ra tags <<< "$TAGS"
+        
+        registered_task_definition=$(aws ecs register-task-definition \
+          --cli-input-json "$(cat "$TASK_DEFINITION_TEMPLATE")" \
+          ${EXECUTION_ROLE_ARN:+--execution-role-arn $EXECUTION_ROLE_ARN} \
+          ${TASK_ROLE_ARN:+--task-role-arn $TASK_ROLE_ARN} \
+          ${TAGS:+--tags ${tags[@]}} \
+          --query "taskDefinition.[taskDefinitionArn, family, revision]" \
+          --output text)
+        
+        read -r arn family revision <<< "$registered_task_definition"
+        echo "Registered task definition \`$family:$revision\`" | tee "$GITHUB_STEP_SUMMARY"
+        echo "task-definition-arn=$arn" >> "$GITHUB_OUTPUT"

--- a/scripts/aws/ecr/check-image-exists.sh
+++ b/scripts/aws/ecr/check-image-exists.sh
@@ -1,0 +1,25 @@
+# Check if a docker image with the specified tags exists in a repository.
+# Return the image digest, if it exists, and optionally print a message to the step summary.
+set -eu
+
+: "${REPOSITORY}"   # ECR repository name
+: "${IMAGE_TAGS}"   # Tags associated with the targeted images, delimited by spaces or newlines
+: "${QUIET:=false}" # Do not print a message to the step summary
+
+base_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+image_digests=$("$base_dir"/get-image-digests.sh)
+[[ $image_digests ]] && read -ra images <<< "$image_digests" || exit 0
+
+if [[ ${#images[@]} -gt 1 ]]; then
+  echo "::error::Expected only one image with tags '$IMAGE_TAGS' but got multiple: ${images[*]}"
+  exit 1
+fi
+
+if [[ ${#images[@]} -eq 1 ]] && ! $QUIET; then
+  read -ra tags <<< "$(tr '\n' ' ' <<< "$IMAGE_TAGS")"
+  [[ ${#tags[@]} -gt 1 ]] && plural=true
+  echo "Image with tag${plural:+s} \`${tags[*]}\` exists in repository \`$REPOSITORY\`" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "${images[*]}"

--- a/scripts/aws/ecr/get-image-digests.sh
+++ b/scripts/aws/ecr/get-image-digests.sh
@@ -5,16 +5,9 @@ set -eu
 
 read -ra tags <<< "$(tr '\n' ' ' <<< "$IMAGE_TAGS")"
 tags=("${tags[@]/#/\'}") && tags=("${tags[@]/%/\'}")
+tag_list=$(IFS=","; echo "[${tags[*]}]")
 
-tag_list=$(
-  IFS=","
-  echo "[${tags[*]}]"
-)
-
-image_list=$(aws ecr list-images \
+aws ecr list-images \
   --repository-name "$REPOSITORY" \
   --query "imageIds[?contains($tag_list, imageTag)].[imageDigest]" \
-  --output text | sort -u)
-
-mapfile -t images <<< "$image_list"
-echo "${images[*]}"
+  --output text | sort -u | tr '\n' ' '


### PR DESCRIPTION
**Split the `ecr/check-image-exists` action**

- Move the logic from the `ecr/check-image-exists` action ino a script.
- Use the script instead of the action in the repo to reduce internal dependencies and simplify the workflows.

---

- Optionally assume AWS role and login to ECR in the deregister stale tasks definitions action
  Allow to pass in the AWS role ARN and the ECR repository name to the action.

- Add an action to render and register ECS task definition