### PR TITLE
SSE-2463: Split the sam/check-stack-exists action

### DIFF
--- a/sam/check-stacks-exist/action.yml
+++ b/sam/check-stacks-exist/action.yml
@@ -20,10 +20,14 @@ runs:
   steps:
     - name: Check stacks exist
       id: check-stacks-exist
-      run: ${{ github.action_path }}/check-stacks-exist.sh
       shell: bash
       env:
         STACK_NAMES: ${{ inputs.stack-names }}
+        CHECK_STACKS: ${{ github.action_path }}/../../scripts/aws/ecr/check-stacks-exist.sh
+      run: |
+        declare -A stacks && eval "stacks=($($CHECK_STACKS))"
+        echo "existing-stacks=${stacks[existing-stacks]:-}" >> "$GITHUB_OUTPUT"
+        echo "missing-stacks=${stacks[missing-stacks]:-}" >> "$GITHUB_OUTPUT"
 
     - name: Set environment variable
       if: ${{ inputs.set-env-var != null && steps.check-stacks-exist.outputs.existing-stacks != null }}

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -18,10 +18,13 @@ runs:
     - name: Check stacks exist
       id: check-stacks-exist
       if: ${{ inputs.stack-names }}
-      uses: alphagov/di-github-actions/sam/check-stacks-exist@4460b10baa63ab00496fe5f5f39495d428018a27
-      with:
-        stack-names: ${{ inputs.stack-names }}
-        verbose: true
+      shell: bash
+      env:
+        STACK_NAMES: ${{ inputs.stack-names }}
+        CHECK_STACKS: ${{ github.action_path }}/../../scripts/aws/ecr/check-stacks-exist.sh
+      run: |
+        declare -A stacks && eval "stacks=($($CHECK_STACKS))"
+        echo "existing-stacks=${stacks[existing-stacks]:-}" >> "$GITHUB_OUTPUT"
 
     - name: Delete stacks
       id: delete-stacks

--- a/scripts/aws/ecr/check-stacks-exist.sh
+++ b/scripts/aws/ecr/check-stacks-exist.sh
@@ -1,7 +1,6 @@
 set -eu
 
-existing_stacks=()
-missing_stacks=()
+: "${STACK_NAMES}" # Names of the stacks to check (space or newline-delimited string)
 
 read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
 
@@ -13,5 +12,7 @@ for stack in "${stacks[@]}"; do
   fi
 done
 
-echo "existing-stacks=${existing_stacks[*]}" >> "$GITHUB_OUTPUT"
-echo "missing-stacks=${missing_stacks[*]}" >> "$GITHUB_OUTPUT"
+results+=("[existing-stacks]='${existing_stacks[*]}'")
+results+=("[missing-stacks]='${missing_stacks[*]}'")
+
+echo "${results[*]}"


### PR DESCRIPTION
**Split the `sam/check-stack-exists` action**

Move the logic from the `sam/check-stack-exists` action ino a script. Use the script instead of the action in the repo to reduce internal dependencies and simplify the workflows.