### PR TITLE
SSE-2496: Fixes and improvements for actions to build and delete stacks

### DIFF
--- a/.github/stubs/aws/stub-aws-cli.sh
+++ b/.github/stubs/aws/stub-aws-cli.sh
@@ -3,22 +3,28 @@ set -eu
 [[ ${1:-} == help ]] && echo "Using stub AWS CLI"
 
 if [[ ${1:-} == cloudformation && ${2:-} == describe-stacks ]]; then
-  stacks="$(dirname "${BASH_SOURCE[0]}")/stacks.json"
+  stacks=$(cat "$(dirname "${BASH_SOURCE[0]}")/stacks.json")
 
-  if [[ ${3:-} == --stack-name ]]; then
-    stack_name="$4"
-    stack_info=$(jq --arg stackName "$stack_name" '.Stacks[] | select(.StackName == $stackName)' < "$stacks")
+  set -- "${@:3}"
+  while [[ ${1:-} ]]; do
+    case $1 in
+    --stack-name) shift && stack_name=$1 ;;
+    --query) shift && query=$1 ;;
+    --output) shift && output=$1 ;;
+    esac
+    shift
+  done
 
-    if [[ $stack_info ]]; then
-      jq '{Stacks: [.]}' <<< "$stack_info"
-      exit 0
-    else
-      echo "Stack $stack_name does not exist"
-      exit 1
-    fi
+  if [[ ${stack_name:-} ]]; then
+    stack_info=$(jq --arg stackName "$stack_name" '.Stacks[] | select(.StackName == $stackName)' <<< "$stacks")
+    [[ $stack_info ]] || (echo "Stack $stack_name does not exist" && exit 1)
+    stacks=$(jq '{Stacks: [.]}' <<< "$stack_info")
   fi
 
-  cat "$stacks"
+  [[ -z ${query:-} ]] || stacks=$(jq ".$query" <<< "$stacks")
+  [[ ${output:-} != text ]] || stacks=$(jq -r <<< "$stacks")
+
+  echo "$stacks"
   exit 0
 fi
 

--- a/aws/ecr/delete-docker-images/action.yml
+++ b/aws/ecr/delete-docker-images/action.yml
@@ -55,6 +55,7 @@ runs:
         echo "digests=$unique_digests" >> "$GITHUB_OUTPUT"
 
     - name: Delete images
+      id: delete-images
       if: ${{ steps.get-image-digests.outputs.digests != null }}
       shell: bash
       env:
@@ -71,6 +72,7 @@ runs:
           --output json | tee "$OUTPUT"
 
     - name: Report deleted images
+      if: ${{ always() && steps.delete-images.outcome != 'skipped' }}
       shell: bash
       env:
         REPOSITORY: ${{ inputs.repository }}

--- a/code-quality/check-linting/action.yml
+++ b/code-quality/check-linting/action.yml
@@ -63,9 +63,7 @@ runs:
     - name: Get files to check
       if: ${{ env.MERGING == 'true' }}
       shell: bash
-      run: |
-        files=$(git diff --name-only --diff-filter=d HEAD^...HEAD | tr '\n' ' ')
-        echo "FILES=$files" >> "$GITHUB_ENV"
+      run: echo "FILES=$(git diff --name-only --diff-filter=d HEAD^...HEAD | xargs)" >> "$GITHUB_ENV"
 
     - name: Run Prettier
       if: ${{ inputs.run-prettier == 'true' && (env.FILES != null || env.MERGING == 'false') }}
@@ -95,11 +93,11 @@ runs:
         
         if $MERGING; then
           files="$(tr ' ' '\n' <<< "$FILES")"
-          read -ra types <<< "$(tr '\n' ' ' <<< "$TYPES")"
-          filetype_regex="$(IFS="|"; echo ".*\.(${types[*]##.})$")"
+          read -ra types < <(xargs <<< "$TYPES")
+          filetype_regex=$(IFS="|" && echo ".*\.(${types[*]##.})$")
         
-          filtered_files="$(grep -E --regexp="$filetype_regex" <<< "$files")" ||
-            (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+          filtered_files=$(grep -E --regexp="$filetype_regex" <<< "$files") ||
+            case $? in 1) echo "No files to check" && exit 0 ;; *) exit $? ;; esac
         
           mapfile -t es_files <<< "$filtered_files"
         fi
@@ -118,16 +116,14 @@ runs:
         echo ":: Running cfn-lint"
         $STRICT && error_on_warnings=true
         
-        if $MERGING; then
-          files="$FILES"
-        else
+        if ! $MERGING; then
           shopt -s globstar dotglob extglob nullglob
           files=$(echo !(.github|node_modules|.aws-sam)/!(node_modules|.aws-sam)/*.@(yaml|yml))
         fi
         
-        read -ra files <<< "$files"
+        read -ra files <<< "${files:-$FILES}"
         filtered_files=$(grep -El --regexp='^AWSTemplateFormatVersion: "?[[:digit:]-]+"?' "${files[@]}") ||
-          (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+          case $? in 1) echo "No files to check" && exit 0 ;; *) exit $? ;; esac
         
         mapfile -t files <<< "$filtered_files"
         cfn-lint ${error_on_warnings:+--non-zero-exit-code warning} "${files[@]}" | tee "$OUTPUT" ||

--- a/code-quality/check-shell-scripts/action.yml
+++ b/code-quality/check-shell-scripts/action.yml
@@ -47,22 +47,23 @@ runs:
       env:
         TYPES: ${{ inputs.file-extensions }}
       run: |
-        read -ra types <<< "$(tr '\n' ' ' <<< "$TYPES")"
+        read -ra types < <(xargs <<< "$TYPES")
+        extensions=$(IFS="|" && echo "${types[*]##.}")
         
         if $MERGING; then
           files=$(git diff --name-only --diff-filter=d HEAD^...HEAD)
-          filetype_regex="$(IFS="|"; echo ".*\.(${types[*]##.})$")"
-
-          filtered_files=$(grep -E --regexp="$filetype_regex" <<< "$files") ||
-            (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
-
-          scripts=$(tr '\n' ' ' <<< "$filtered_files")
+          filter=".*\.($extensions)$"
         else
           shopt -s globstar dotglob extglob nullglob
-          scripts=$(IFS="|"; eval echo "**/*@(${types[*]})")
+          files=$(eval echo "**/*.@($extensions)")
+          filter="node_modules|\.aws-sam"
+          exclude=true
         fi
         
-        echo "SCRIPTS=$scripts" >> "$GITHUB_ENV"
+        scripts=$(grep -E ${exclude:+--invert-match} --regexp="$filter" < <(tr ' ' '\n' <<< "${files[*]}")) ||
+          case $? in 1) echo "No files to check" && exit 0 ;; *) exit $? ;; esac
+        
+        echo "SCRIPTS=$(xargs <<< "$scripts")" >> "$GITHUB_ENV"
 
     - name: Run shellcheck
       if: ${{ env.SCRIPTS != null && inputs.run-shellcheck == 'true' }}

--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -48,11 +48,11 @@ runs:
         SKIP_FRAMEWORKS: ${{ inputs.skip-frameworks }}
       run: |
         if [[ -n $SKIP_CHECKS ]]; then
-          echo "skip-checks=--skip-check $(echo -n "$SKIP_CHECKS" | tr '\n' ' ' | tr ' ' ',')" >> "$GITHUB_OUTPUT"
+          echo "skip-checks=--skip-check $(xargs <<< "$SKIP_CHECKS" | tr ' ' ',')" >> "$GITHUB_OUTPUT"
         fi
         
         if [[ -n $SKIP_FRAMEWORKS ]]; then
-          echo "skip-frameworks=--skip-framework $(echo -n "$SKIP_FRAMEWORKS" | tr '\n' ',' | tr ',' ' ')" >> "$GITHUB_OUTPUT"
+          echo "skip-frameworks=--skip-framework $(xargs <<< "$SKIP_FRAMEWORKS")" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Get pull request files
@@ -64,10 +64,12 @@ runs:
       run: |
         files=$(git diff --name-only --diff-filter=d HEAD^...HEAD)
         
-        [[ -z $DIR ]] || files=$(grep -E --regexp="^.*\/${DIR}\/.*$" <<< "$files") ||
-          (status=$? && [[ $status -eq 1 ]] && echo "No files to check" || exit $status) && exit
+        if [[ $DIR ]]; then
+          files=$(grep -E --regexp="^.*\/${DIR}\/.*$" <<< "$files") ||
+            case $? in 1) echo "No files to check" && exit 0 ;; *) exit $? ;; esac
+        fi
         
-        echo "files=$(tr '\n' ' ' <<< "$files")" >> "$GITHUB_OUTPUT"
+        echo "files=$(xargs <<< "$files")" >> "$GITHUB_OUTPUT"
 
     - name: Run Checkov on a pull request
       if: ${{ steps.check-merge-commit.outputs.merging == 'true' && steps.get-pr-files.outputs.files != null }}

--- a/sam/build-application/action.yml
+++ b/sam/build-application/action.yml
@@ -1,31 +1,39 @@
-name: 'Build an AWS SAM application'
-description: 'Validates and builds the specified SAM application. The built artifact is found in the .aws-sam directory'
+name: "Build an AWS SAM application"
+description: "Validates and builds the specified SAM application. The built artifact is found in the .aws-sam directory"
 inputs:
-  sam-template-file:
-    description: 'Name of the SAM template file to use'
-    required: false
   aws-role-arn:
-    description: 'AWS role ARN to assume when validating the template'
-    required: true
+    description: "AWS role ARN to assume when validating the template"
+    required: false
   aws-region:
-    description: 'AWS region to use'
+    description: "AWS region to use"
     required: false
     default: eu-west-2
   aws-session-name:
-    description: 'Override the default AWS session name'
+    description: "Override the default AWS session name"
+    required: false
+  sam-template-file:
+    description: "Name of the SAM template file to use"
+    required: false
+  base-dir:
+    description: "Resolve relative paths to lambda functions' source code with respect to this folder"
     required: false
   enable-beta-features:
-    description: 'Use SAM beta features when building an application'
+    description: "Use SAM beta features when building an application"
     required: false
-    default: 'false'
+    default: "false"
   disable-cache:
-    description: 'Set to true to use the --no-cached option'
+    description: "Set to true to build without the cache"
     required: false
-    default: 'false'
+    default: "false"
+  disable-parallel:
+    description: "Set to true to build the resources sequentially"
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
     - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn }}
       uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
@@ -36,16 +44,22 @@ runs:
       shell: bash
       env:
         TEMPLATE_FILE: ${{ inputs.sam-template-file }}
-      run: sam validate ${TEMPLATE_FILE:+--template-file $TEMPLATE_FILE}
+      run: |
+        sam validate ${TEMPLATE_FILE:+--template-file "$TEMPLATE_FILE"}
+        sam validate ${TEMPLATE_FILE:+--template-file "$TEMPLATE_FILE"} --lint
 
     - name: Build SAM Application
       shell: bash
       env:
         TEMPLATE_FILE: ${{ inputs.sam-template-file }}
         BETA_FEATURES: ${{ inputs.enable-beta-features == 'true' }}
-        DISABLE_CACHE: ${{ inputs.disable-cache == 'true' }}
+        PARALLEL: ${{ inputs.disable-parallel == 'false' }}
+        CACHE: ${{ inputs.disable-cache == 'false' }}
+        BASE_DIR: ${{ inputs.base-dir }}
       run: |
-        sam build --parallel \
-          $($DISABLE_CACHE || echo "--cached") \
-          $($BETA_FEATURES && echo "--beta-features") \
-          ${TEMPLATE_FILE:+--template-file $TEMPLATE_FILE}
+        sam build \
+          ${TEMPLATE_FILE:+--template-file "$TEMPLATE_FILE"} \
+          ${BASE_DIR:+--base-dir "$BASE_DIR"} \
+          "$($PARALLEL && echo "--parallel")" \
+          "$($CACHE && echo "--cached" || echo "--no-cached")" \
+          "$($BETA_FEATURES && echo "--beta-features")"

--- a/sam/delete-stacks/action.yml
+++ b/sam/delete-stacks/action.yml
@@ -1,13 +1,19 @@
 name: 'Delete SAM stacks'
 description: 'Delete existing AWS SAM stacks and optionally check their state'
 inputs:
+  aws-role-arn:
+    description: "AWS role ARN to assume when validating the template"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
+  aws-session-name:
+    description: "Override the default AWS session name"
+    required: false
   stack-names:
     description: 'Names of the stacks to delete (space or newline-delimited string)'
     required: true
-  aws-region:
-    description: 'AWS region to use'
-    required: false
-    default: eu-west-2
   only-if-failed:
     description: 'Delete a stack only if it is in one of the failed states'
     required: false
@@ -15,6 +21,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn }}
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        role-session-name: ${{ inputs.aws-session-name }}
+        aws-region: ${{ inputs.aws-region }}
+
     - name: Check stacks exist
       id: check-stacks-exist
       if: ${{ inputs.stack-names }}
@@ -42,6 +56,7 @@ runs:
       env:
         DELETED_STACKS: ${{ steps.delete-stacks.outputs.deleted-stacks }}
         FAILED_STACKS: ${{ steps.delete-stacks.outputs.failed-stacks }}
+        IGNORED_STACKS: ${{ steps.delete-stacks.outputs.ignored-stacks }}
         REPORT: ${{ github.action_path }}/../../scripts/report-step-result/print-list.sh
       run: |
         VALUES=$DELETED_STACKS MESSAGE="Deleted stacks" SINGLE_MESSAGE="Deleted stack %s" $REPORT |
@@ -49,3 +64,5 @@ runs:
         
         VALUES=$FAILED_STACKS MESSAGE="Failed to delete stacks" SINGLE_MESSAGE="Failed to delete stack %s" $REPORT |
           tee -a "$GITHUB_STEP_SUMMARY"
+        
+        VALUES=$IGNORED_STACKS MESSAGE="Ignored stacks in a good state" SINGLE_MESSAGE="Ignored stack %s in a good state" $REPORT

--- a/sam/delete-stacks/delete-stacks.sh
+++ b/sam/delete-stacks/delete-stacks.sh
@@ -6,7 +6,7 @@ delete_only_failed=${ONLY_FAILED}
 deleted_stacks=()
 failed_stacks=()
 
-read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
+read -ra stacks < <(xargs <<< "${STACK_NAMES}")
 
 for stack in "${stacks[@]}"; do
   if $delete_only_failed; then

--- a/sam/delete-stacks/delete-stacks.sh
+++ b/sam/delete-stacks/delete-stacks.sh
@@ -1,28 +1,30 @@
 set -eu
 
-region=${AWS_REGION}
 delete_only_failed=${ONLY_FAILED}
-
-deleted_stacks=()
-failed_stacks=()
+failed=()
 
 read -ra stacks < <(xargs <<< "${STACK_NAMES}")
 
 for stack in "${stacks[@]}"; do
   if $delete_only_failed; then
-    stack_info=$(aws cloudformation describe-stacks --stack-name "$stack")
-    stack_state=$(jq -r '.Stacks[].StackStatus' <<< "$stack_info")
+    stack_state=$(aws cloudformation describe-stacks \
+      --stack-name "$stack" \
+      --query "Stacks[].StackStatus" \
+      --output text)
 
-    if ! [[ $stack_state =~ FAILED ]]; then
-      echo "Stack '$stack' is in a good state: '$stack_state' - not deleting"
+    if ! [[ $stack_state =~ _FAILED$ ]]; then
+      ignored+=("$stack")
       continue
     fi
   fi
 
-  sam delete --no-prompts --region "$region" --stack-name "$stack" && deleted_stacks+=("$stack") || failed_stacks+=("$stack")
+  sam delete --no-prompts --region "$AWS_REGION" --stack-name "$stack" && deleted+=("$stack") || failed+=("$stack")
 done
 
-echo "deleted-stacks=${deleted_stacks[*]}" >> "$GITHUB_OUTPUT"
-echo "failed-stacks=${failed_stacks[*]}" >> "$GITHUB_OUTPUT"
+{
+  echo "deleted-stacks=${deleted[*]}"
+  echo "failed-stacks=${failed[*]}"
+  echo "ignored-stacks=${ignored[*]}"
+} >> "$GITHUB_OUTPUT"
 
-[[ ${#failed_stacks[@]} -eq 0 ]] || exit 1
+[[ ${#failed[@]} -eq 0 ]] || exit 1

--- a/scripts/aws/sam/check-stacks-exist.sh
+++ b/scripts/aws/sam/check-stacks-exist.sh
@@ -2,7 +2,7 @@ set -eu
 
 : "${STACK_NAMES}" # Names of the stacks to check (space or newline-delimited string)
 
-read -ra stacks <<< "$(tr '\n' ' ' <<< "${STACK_NAMES}")"
+read -ra stacks < <(xargs <<< "${STACK_NAMES}")
 
 for stack in "${stacks[@]}"; do
   if aws cloudformation describe-stacks --stack-name "$stack" > /dev/null; then


### PR DESCRIPTION
**Improvements to building SAM applications**
Add additional options to the `sam/build-application` action:
  - Disable parallel build
  - Set base directory to use for the build
  - Make AWS login optional if the role ARN is provided
  - Run additional validation on the SAM template

**Improvements to deleting SAM stacks**
Add functionality to the `sam/delete-stacks` action:
  - Add option to log into AWS if the role ARN is provided
  - Log stack names that were in a good state and ignored for deletion
  - Return ignored stacks with the output rather than printing to the console to fix a bug

**Fix issue with linting actions**
Fix a bug when jobs would always exit regardless of whether grep found matches.
This was caused by the `&& exit` appended to the end of the command that would be executed if grep returned without an error, regardless of the result of the preceding subshell. Fix the issue by scrapping the subshell and using a case statement to check grep's exit status if the command had returned with an error.

**Adjust stub AWS CLI for testing**

Make changes to the stub to be more robust when retrieving fake stacks, to allow it to work with the recent changes to the stack actions.

Add the ability to apply queries and return raw output.

---

- Use xargs to tidy up inputs instead `tr '\n' ' '`
- Don't report deleted docker images if the job hasn't run