### PR TITLE
SSE-2521: Add an action to retrieve SSM params

### DIFF
--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -53,7 +53,10 @@ outputs:
     value: ${{ inputs.image-tags }}
   image-uri:
     description: "Image URI in the format <registry>/<repository>@<digest>"
-    value: ${{ steps.set-image-uri.outputs.image-uri }}
+    value: ${{ steps.get-image-uri.outputs.image-uri }}
+  image-url:
+    description: "URL of the pushed Docker image in the AWS console"
+    value: ${{ steps.check-image-exists.outputs.image-url || steps.report-pushed-image.outputs.image-url }}
 runs:
   using: composite
   steps:
@@ -78,32 +81,40 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-version }}
         CHECK_IMAGE: ${{ github.action_path }}/../../../scripts/aws/ecr/check-image-exists.sh
-      run: |
-        image_digest=$($CHECK_IMAGE)
-        echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"
+        VERBOSE: "true"
+      run: $CHECK_IMAGE
 
-    - name: Delete previous image version
+    - name: Check previous image version exists
+      id: check-previous-image-exists
       if: ${{ inputs.immutable-tags == 'true' && steps.check-image-exists.outputs.image-digest == null }}
       shell: bash
       env:
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
         CHECK_IMAGE: ${{ github.action_path }}/../../../scripts/aws/ecr/check-image-exists.sh
-        REPORT: ${{ github.action_path }}/../../../scripts/report-step-result/print-file.sh
-        TITLE: Deleted previous image version
-        LANGUAGE: shell
+      run: $CHECK_IMAGE
+
+    - name: Delete previous image version
+      if: ${{ steps.check-previous-image-exists.outputs.image-digest != null }}
+      shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        IMAGE_DIGEST: ${{ steps.check-previous-image-exists.outputs.image-digest }}
       run: |
-        image_digest=$($CHECK_IMAGE)
-        if ! [[ $image_digest ]]; then
-          echo "Previous version of image with tags '$(xargs <<< "$IMAGE_TAGS")' not found"
-          exit
+        deleted_image=$(aws ecr batch-delete-image \
+          --repository-name "$REPOSITORY" \
+          --image-ids imageDigest="$IMAGE_DIGEST" \
+          --output json)
+        
+        failure_reason=$(jq -r '.failures[].failureReason' <<< "$deleted_image")
+        
+        if [[ $failure_reason ]]; then
+          echo "❌ Failed to delete previous image version. $failure_reason" | tee "$GITHUB_STEP_SUMMARY"
+          exit 1
         fi
         
-        echo "Deleting previous image version..."
-        aws ecr batch-delete-image \
-          --repository-name "$REPOSITORY" \
-          --image-ids imageDigest="$image_digest" \
-          --output text | $REPORT | tee "$GITHUB_STEP_SUMMARY"
+        deleted_image_tags=$(jq -r '.imageIds[].imageTag' <<< "$deleted_image" | xargs)
+        echo "🚮 Deleted previous image version (\`$deleted_image_tags\`)" | tee "$GITHUB_STEP_SUMMARY"
 
     - name: Build Docker image
       id: build-image
@@ -153,14 +164,18 @@ runs:
         fi
         
         digest=${digests[*]}
+        url="https://${AWS_REGION}.console.aws.amazon.com/ecr/repositories/private/${REGISTRY%%.*}/${REPOSITORY}/_/image/${digest}/details"
+        
+        echo "image-digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "image-url=$url" >> "$GITHUB_OUTPUT"
+
         [[ ${#tags[@]} -le 1 ]] || plural=true
         [[ ${#tags[@]} -le 0 ]] || tag_msg="tag${plural:+s} \`${tags[*]}\`"
         
-        echo "Pushed image with ${tag_msg:-digest \`$digest\`} to repository \`$REPOSITORY\`" >> "$GITHUB_STEP_SUMMARY"
-        echo "image-digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "🐳 Pushed [image with ${tag_msg:-digest \`$digest\`}]($url) to repository \`$REPOSITORY\`" >> "$GITHUB_STEP_SUMMARY"
 
-    - name: Set image URI
-      id: set-image-uri
+    - name: Get image URI
+      id: get-image-uri
       shell: bash
       env:
         REGISTRY: ${{ inputs.registry || steps.login-ecr.outputs.registry }}

--- a/aws/ecr/check-image-exists/action.yml
+++ b/aws/ecr/check-image-exists/action.yml
@@ -7,24 +7,29 @@ inputs:
   image-tags:
     description: "Tags associated with the targeted image, delimited by spaces or newlines"
     required: true
+  verbose:
+    description: "Print message to the step summary"
+    required: false
+    default: "true"
 outputs:
   image-exists:
     description: "Boolean indicating whether the image exists"
-    value: ${{ steps.check-image-exists.outputs.image-exists }}
+    value: ${{ steps.check-image-exists.outputs.image-digest != null }}
   image-digest:
     description: "Digest of the image if it exists"
     value: ${{ steps.check-image-exists.outputs.image-digest }}
+  image-url:
+    description: "URL of the ECR image in the AWS console"
+    value: ${{ steps.check-image-exists.outputs.image-url }}
 runs:
   using: composite
   steps:
     - name: Check image exists
+      id: check-image-exists
       shell: bash
       env:
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
         CHECK_IMAGE: ${{ github.action_path }}/../../../scripts/aws/ecr/check-image-exists.sh
-      run: |
-        image_digest=$($CHECK_IMAGE)
-        [[ $image_digest ]] && image_exists=true || image_exists=false
-        echo "image-exists=$image_exists" >> "$GITHUB_OUTPUT"
-        echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"
+        VERBOSE: ${{ inputs.verbose == 'true' }}
+      run: $CHECK_IMAGE

--- a/aws/ecr/delete-docker-images/action.yml
+++ b/aws/ecr/delete-docker-images/action.yml
@@ -93,13 +93,13 @@ runs:
         
         for digest in "${failed_digests[@]}"; do
           failure_reason=$(jq -r --arg digest "$digest" '.failures[] | select(.imageId.imageDigest == $digest) | .failureReason' "$RESULTS")
-          fail_messages+=("$digest ($failure_reason)")
+          fail_messages+=("\`$digest\`: $failure_reason")
         done
         
         IFS=$'\n' && VALUES="${success_messages[*]}"$'\n' MESSAGE="Deleted images from repository \`${REPOSITORY}\`" \
           SINGLE_MESSAGE="Deleted image %s from repository \`${REPOSITORY}\`" $REPORT | tee -a "$GITHUB_STEP_SUMMARY"
         
         IFS=$'\n' && VALUES="${fail_messages[*]}"$'\n' MESSAGE="Failed to delete images from repository \`${REPOSITORY}\`" \
-          SINGLE_MESSAGE="Failed to delete image %s from repository \`${REPOSITORY}\`" "$REPORT" | tee -a "$GITHUB_STEP_SUMMARY"
+          SINGLE_MESSAGE="Failed to delete image from repository \`${REPOSITORY}\`"$'\n'%s CODE_BLOCK=false $REPORT | tee -a "$GITHUB_STEP_SUMMARY"
         
         [[ ${#failed_digests[@]} -gt 0 ]] && $ERROR_STATUS && exit 1 || exit 0

--- a/aws/ecr/get-image-digests/action.yml
+++ b/aws/ecr/get-image-digests/action.yml
@@ -21,4 +21,6 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         IMAGE_TAGS: ${{ inputs.image-tags }}
         IMAGE_DIGESTS: ${{ github.action_path }}/../../../scripts/aws/ecr/get-image-digests.sh
-      run: echo "image-digests=$($IMAGE_DIGESTS)" >> "$GITHUB_OUTPUT"
+      run: |
+        image_digests=$($IMAGE_DIGESTS)
+        echo "image-digests=$image_digests" >> "$GITHUB_OUTPUT"

--- a/aws/ecs/deregister-stale-task-definitions/deregister-stale-task-definitions.sh
+++ b/aws/ecs/deregister-stale-task-definitions/deregister-stale-task-definitions.sh
@@ -33,7 +33,7 @@ for task_definition in "${task_definitions[@]}"; do
 
   if ! aws ecr describe-images \
     --repository-name "$image_repo" \
-    --image-ids "$image_query" > /dev/null 2>&1; then
+    --image-ids "$image_query" &> /dev/null; then
 
     task_definition_version="${task_definition#*task-definition/}"
     echo "Image with ID '$image_query' not found in repository '$image_repo':" \

--- a/aws/ecs/register-task-definition/action.yml
+++ b/aws/ecs/register-task-definition/action.yml
@@ -36,6 +36,9 @@ outputs:
   task-definition-arn:
     description: "The ARN of the registered task definition"
     value: ${{ steps.register-task-definition.outputs.task-definition-arn }}
+  task-definition-url:
+    description: "URL of the registered task definition in the AWS console"
+    value: ${{ steps.register-task-definition.outputs.task-definition-url }}
 runs:
   using: composite
   steps:
@@ -86,5 +89,9 @@ runs:
           --output text)
         
         read -r arn family revision <<< "$registered_task_definition"
-        echo "Registered task definition \`$family:$revision\`" | tee "$GITHUB_STEP_SUMMARY"
+        url="https://${AWS_REGION}.console.aws.amazon.com/ecs/v2/task-definitions/${family}/${revision}"        
+
         echo "task-definition-arn=$arn" >> "$GITHUB_OUTPUT"
+        echo "task-definition-url=$url" >> "$GITHUB_OUTPUT"
+
+        echo "📝 Registered [task definition \`$family:$revision\`]($url)" | tee "$GITHUB_STEP_SUMMARY"

--- a/aws/ssm/get-parameters/action.yml
+++ b/aws/ssm/get-parameters/action.yml
@@ -1,0 +1,84 @@
+name: "Get parameters from the SSM Parameter Store"
+description: "Retrieve parameters by name or path; return a JSON object with parameter values keyed by their names"
+inputs:
+  aws-role-arn:
+    description: "ARN of the AWS role to assume"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
+  aws-session-name:
+    description: "Override the default AWS session name"
+    required: false
+  parameter-names:
+    description: "Names of the parameters to retrieve; multiple values delimited by spaces or newlines"
+    required: false
+  parameter-path:
+    description: "Retrieve parameters in a specific hierarchy; starts with a /"
+    required: false
+  recursive:
+    description: "Retrieve all parameters within a hierarchy when using a path (get parameters from all sub-paths)"
+    required: false
+    default: "false"
+  trim-path:
+    description: "Exclude the parameter hierarchy from the object keys (the keys will be the part after the last /)"
+    required: false
+    default: "false"
+outputs:
+  parameters:
+    description: "A JSON object with parameter values keyed by their names"
+    value: ${{ steps.get-parameters.outputs.parameters }}
+runs:
+  using: composite
+  steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn != null }}
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        role-session-name: ${{ inputs.aws-session-name }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Get named parameters
+      id: get-named-params
+      if: ${{ inputs.parameter-names != null }}
+      shell: bash
+      env:
+        PARAM_NAMES: ${{ inputs.parameter-names }}
+      run: |
+        read -ra param_names < <(xargs <<< "$PARAM_NAMES")
+        
+        echo "parameters=" \
+          "$(aws ssm get-parameters \
+            --names "${param_names[@]}" \
+            --query "Parameters[].{name: Name, value: Value}" \
+            --output json | jq --compact-output)" >> "$GITHUB_OUTPUT"
+
+    - name: Get parameters by path
+      id: get-path-params
+      if: ${{ inputs.parameter-path != null }}
+      shell: bash
+      env:
+        PARAM_PATH: ${{ inputs.parameter-path }}
+        RECURSIVE: ${{ inputs.recursive == 'true' }}
+      run: |
+        echo "parameters=" \
+          "$(aws ssm get-parameters-by-path \
+            --path "$PARAM_PATH" \
+            "$($RECURSIVE && echo "--recursive")" \
+            --query "Parameters[].{name: Name, value: Value}" \
+            --output json | jq --compact-output)" >> "$GITHUB_OUTPUT"
+
+    - name: Get parameter values
+      id: get-parameters
+      if: ${{ join(steps.*.outputs.parameters, '') != null }}
+      shell: bash
+      env:
+        PARAMETERS: ${{ join(steps.*.outputs.parameters, '') }}
+        PARAM_PATH: ${{ inputs.parameter-path }}
+        TRIM_PATH: ${{ inputs.trim-path == 'true' }}
+      run: |
+        $TRIM_PATH && trim_filter='|sub(".*\/"; "")'
+        parameters=$(jq --slurp --compact-output "flatten | map({(.name${trim_filter:-}): .value}) | add" <<< "$PARAMETERS")
+        echo "parameters=$parameters" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- Output resource URLs for ECS and ECR
   Construct and return URLs of the pushed docker images and registered task definitions.

- Improve messages printed to the step summaries.

- Add the verbose option to the `aws/ecr/check-image-exists` action.

- Add an action to retrieve parameter values from SSM