### PR TITLE
SSE-2496: Fix bug in sam/deploy-stack action

### DIFF
--- a/sam/deploy-stack/action.yml
+++ b/sam/deploy-stack/action.yml
@@ -60,15 +60,22 @@ runs:
       if: ${{ inputs.parameters != null }}
       shell: bash
       env:
-        TAGS: ${{ inputs.tags }}
-        PARAMS: ${{ inputs.parameters }}
+        PARAMETERS: ${{ inputs.parameters }}
         PARSE: ${{ github.action_path }}/../../scripts/parse-parameters.sh
       run: |
-        tags=$(PARAMETERS=$TAGS $PARSE)
-        parameters=$(PARAMETERS=$PARAMS $PARSE)
-        
-        echo "tags=$tags" >> "$GITHUB_OUTPUT"
+        parameters=$($PARSE)
         echo "parameters=$parameters" >> "$GITHUB_OUTPUT"
+
+    - name: Parse tags
+      id: parse-tags
+      if: ${{ inputs.tags != null }}
+      shell: bash
+      env:
+        PARAMETERS: ${{ inputs.tags }}
+        PARSE: ${{ github.action_path }}/../../scripts/parse-parameters.sh
+      run: |
+        tags=$($PARSE)
+        echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
     - name: Get stack name from branch
       id: get-branch-name
@@ -110,7 +117,7 @@ runs:
         S3_BUCKET: ${{ inputs.sam-deployment-bucket }}
         DISABLE_ROLLBACK: ${{ inputs.disable-rollback == 'true' }}
         PARAMETERS: ${{ steps.parse-parameters.outputs.parameters }}
-        TAGS: ${{ steps.parse-parameters.outputs.tags }}
+        TAGS: ${{ steps.parse-tags.outputs.tags }}
       run: |
         sam deploy \
           --stack-name "$STACK_NAME" \

--- a/scripts/parse-parameters.sh
+++ b/scripts/parse-parameters.sh
@@ -4,6 +4,8 @@ set -eu
 : "${ASSOCIATIVE_ARRAY:=false}" # Whether to encode output as a string representing an associative array
 : "${LONG_FORMAT:=false}"       # Whether to encode the parameters in the form of "key=key,value='value'" strings
 
+[[ $PARAMETERS ]] || exit 0
+
 raw_parameters=$(echo -n "${PARAMETERS}")
 associative=${ASSOCIATIVE_ARRAY}
 long=${LONG_FORMAT}


### PR DESCRIPTION
Parse tags also when params are not present.
Exit from the parse params script if there are no values to parse.