### PR TITLE
SSE-2521: Add an option to the get SSM params action to fail if params are missing

### DIFF
--- a/.github/workflows/test-delete-stacks.yml
+++ b/.github/workflows/test-delete-stacks.yml
@@ -14,6 +14,13 @@ jobs:
       - name: Pull repository
         uses: actions/checkout@v3
 
+      - name: Install jp
+        shell: bash
+        run: |
+          echo "::group::Install packages"
+          sudo apt-get update && sudo apt-get install jp
+          echo "::endgroup::"
+
       - name: Set up stub AWS CLI
         run: echo "./.github/stubs/aws" >> "$GITHUB_PATH"
 

--- a/.github/workflows/test-get-ssm-parameters.yml
+++ b/.github/workflows/test-get-ssm-parameters.yml
@@ -11,13 +11,6 @@ jobs:
       - name: Pull repository
         uses: actions/checkout@v3
 
-      - name: Install jp
-        shell: bash
-        run: |
-          echo "::group::Install packages"
-          sudo apt-get update && sudo apt-get install jp
-          echo "::endgroup::"
-
       - name: Set up stub AWS CLI
         run: echo "./.github/stubs/aws" >> "$GITHUB_PATH"
 
@@ -250,6 +243,7 @@ jobs:
         with:
           parameter-names: six seven eight nine
           parameter-path: /some/param/path/
+          fail-if-params-missing: false
 
       - name: Verify empty object returned
         env:
@@ -259,3 +253,60 @@ jobs:
           [[ $(jq length <<< "$PARAMS") -eq 0 ]]
           [[ $PARAMS == "{}" ]]
           [[ -z $EMPTY_VALUE ]]
+
+
+      - name: Return existing named params when some are missing
+        id: some-named-params-missing
+        uses: ./aws/ssm/get-parameters
+        with:
+          parameter-names: one two ten
+          parameter-path: /some/param/path/
+          fail-if-params-missing: false
+
+      - name: Verify existing named params returned
+        env:
+          PARAMS: ${{ steps.some-named-params-missing.outputs.parameters }}
+          VALUE_ONE: ${{ fromJSON(steps.some-named-params-missing.outputs.parameters).one }}
+          VALUE_TWO: ${{ fromJSON(steps.some-named-params-missing.outputs.parameters).two }}
+        run: |
+          [[ $(jq length <<< "$PARAMS") -eq 2 ]]
+          
+          [[ $(jq --raw-output '.one' <<< "$PARAMS") == "simple-one" ]]
+          [[ $(jq --raw-output '.two' <<< "$PARAMS") == "simple-two" ]]
+          
+          [[ $VALUE_ONE == "simple-one" ]]
+          [[ $VALUE_TWO == "simple-two" ]]
+
+
+      - name: Exit with error if named parameters are missing
+        id: named-params-missing
+        continue-on-error: true
+        uses: ./aws/ssm/get-parameters
+        with:
+          parameter-names: one two ten
+          fail-if-params-missing: true
+
+      - name: Verify error status if named parameters are missing
+        env:
+          STATUS: ${{ steps.named-params-missing.outcome }}
+          PARAMS: ${{ steps.named-params-missing.outputs.parameters }}
+        run: |
+          [[ $STATUS == failure ]]          
+          [[ -z $PARAMS ]]
+
+
+      - name: Exit with error if path parameters are missing
+        id: path-params-missing
+        continue-on-error: true
+        uses: ./aws/ssm/get-parameters
+        with:
+          parameter-path: /some/param/path/
+          fail-if-params-missing: true
+
+      - name: Verify error status if named parameters are missing
+        env:
+          STATUS: ${{ steps.path-params-missing.outcome }}
+          PARAMS: ${{ steps.path-params-missing.outputs.parameters }}
+        run: |
+          [[ $STATUS == failure ]]          
+          [[ -z $PARAMS ]]

--- a/aws/ssm/get-parameters/action.yml
+++ b/aws/ssm/get-parameters/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Exclude the parameter hierarchy from the object keys (the keys will be the part after the last /)"
     required: false
     default: "false"
+  fail-if-params-missing:
+    description: "Exit with an error status if any parameters are not present; otherwise return empty values"
+    required: false
+    default: "true"
 outputs:
   parameters:
     description: "A JSON object with parameter values keyed by their names"
@@ -46,14 +50,18 @@ runs:
       shell: bash
       env:
         PARAM_NAMES: ${{ inputs.parameter-names }}
+        ERROR_STATUS: ${{ inputs.fail-if-params-missing == 'true' }}
       run: |
         read -ra param_names < <(xargs <<< "$PARAM_NAMES")
         
-        echo "parameters=" \
-          "$(aws ssm get-parameters \
-            --names "${param_names[@]}" \
-            --query "Parameters[].{name: Name, value: Value}" \
-            --output json | jq --compact-output)" >> "$GITHUB_OUTPUT"
+        params=$(aws ssm get-parameters --names "${param_names[@]}" --output json)
+        values=$(jq --compact-output --join-output '.Parameters[] | {Name, Value}' <<< "$params")
+        echo "parameters=$values" >> "$GITHUB_OUTPUT"
+        
+        if $ERROR_STATUS && missing=$(jq --raw-output --exit-status '.InvalidParameters[]' <<< "$params" | xargs); then
+          echo "Parameters not found: $missing"
+          exit 1
+        fi
 
     - name: Get parameters by path
       id: get-path-params
@@ -62,17 +70,20 @@ runs:
       env:
         PARAM_PATH: ${{ inputs.parameter-path }}
         RECURSIVE: ${{ inputs.recursive == 'true' }}
+        ERROR_STATUS: ${{ inputs.fail-if-params-missing == 'true' }}
       run: |
-        echo "parameters=" \
-          "$(aws ssm get-parameters-by-path \
-            --path "$PARAM_PATH" \
-            "$($RECURSIVE && echo "--recursive" || echo "--no-recursive")" \
-            --query "Parameters[].{name: Name, value: Value}" \
-            --output json | jq --compact-output)" >> "$GITHUB_OUTPUT"
+        $RECURSIVE && recursive="--recursive"
+        
+        if ! params=$(aws ssm get-parameters-by-path --path "$PARAM_PATH" ${recursive:-} --output json |
+          jq --compact-output --join-output --exit-status '.Parameters[] | {Name, Value}') && $ERROR_STATUS; then
+          echo "No parameters found with the path '$PARAM_PATH'"
+          exit 1
+        fi
+        
+        echo "parameters=$params" >> "$GITHUB_OUTPUT"
 
     - name: Get parameter values
       id: get-parameters
-      if: ${{ join(steps.*.outputs.parameters, '') != null }}
       shell: bash
       env:
         PARAMETERS: ${{ join(steps.*.outputs.parameters, '') }}
@@ -81,5 +92,5 @@ runs:
       run: |
         $TRIM_PATH && trim_filter='|sub(".*\/"; "")'
         parameters=$(jq --slurp --compact-output --exit-status \
-          "flatten | map({(.name${trim_filter:-}): .value}) | add" <<< "$PARAMETERS") || parameters="{}"
+          "flatten | map({(.Name${trim_filter:-}): .Value}) | add" <<< "$PARAMETERS") || parameters="{}"
         echo "parameters=$parameters" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Add an option to exit with a status code if some params are missing, or to ignore the missing params and return whatever is found.

Adjust the stub AWS CLI to return an array for missing params