### PR TITLE
SSE-2685: Add workflows to deploy applications through secure pipelines

### DIFF
--- a/scripts/aws/codepipeline/await-pipeline-execution.sh
+++ b/scripts/aws/codepipeline/await-pipeline-execution.sh
@@ -1,0 +1,16 @@
+# Wait for a pipeline to finish the execution with the given ID
+set -eu
+
+: "${PIPELINE_NAME}"
+: "${EXECUTION_ID}"
+
+echo -n "Waiting for the pipeline '$PIPELINE_NAME' to finish execution \`$EXECUTION_ID\`..."
+query="pipelineExecutionSummaries[?pipelineExecutionId=='$EXECUTION_ID'].status"
+
+while [[ ${status:-InProgress} == InProgress ]]; do
+  status=$(aws codepipeline list-pipeline-executions --pipeline-name "$PIPELINE_NAME" --query "$query" --output text)
+  echo -n "." && sleep 5
+done
+
+[[ $status == Succeeded ]] && exit
+echo "Pipeline \`$PIPELINE_NAME\` finished execution with the status \`$status\`" | tee "$GITHUB_STEP_SUMMARY" && exit 1

--- a/scripts/aws/codepipeline/get-execution-id.sh
+++ b/scripts/aws/codepipeline/get-execution-id.sh
@@ -1,0 +1,33 @@
+# Get a pipeline execution ID for a given revision ID that started after a given timestamp
+set -eu
+
+: "${PIPELINE_NAME}"
+: "${REVISION_ID}"     # The artifact version that triggered the execution
+: "${STARTED_AFTER:-}" # Look for an execution whose start time is after the given timestamp
+: "${TIMEOUT_MINS:-5}" # Maximum number of minutes to wait for the execution to start
+
+[[ $STARTED_AFTER ]] && start=$(date --date="$STARTED_AFTER" +%s)
+[[ $TIMEOUT_MINS ]] && timeout=$((TIMEOUT_MINS * 60)) elapsed=0
+
+echo -n "Waiting for the pipeline '$PIPELINE_NAME' to start execution..."
+query="pipelineExecutionSummaries[?contains(sourceRevisions[].revisionId, '$REVISION_ID')]|[0]"
+
+while true; do
+  execution=$(aws codepipeline list-pipeline-executions --pipeline-name "$PIPELINE_NAME" --query "$query")
+
+  if [[ $execution != null ]]; then
+    [[ ${start:-} ]] || break
+    [[ $start < $(date --date="$(jq --raw-output '.startTime' <<< "$execution")" +s%) ]] && break
+  fi
+
+  [[ ${timeout:-} ]] && elapsed=$((elapsed + 5)) && [[ $elapsed -gt $timeout ]] && unset execution && break
+  echo -n "." && sleep 5
+done
+
+if [[ ${execution:-} ]]; then
+  echo "execution-id=$(jq --raw-output '.pipelineExecutionId' <<< "$execution")" >> "$GITHUB_OUTPUT"
+  exit
+fi
+
+echo "Pipeline \`$PIPELINE_NAME\` didn't start execution within the $TIMEOUT_MINUTES minute timeout" |
+  tee "$GITHUB_STEP_SUMMARY" && exit 1

--- a/scripts/aws/codepipeline/get-pipeline-url.sh
+++ b/scripts/aws/codepipeline/get-pipeline-url.sh
@@ -1,0 +1,8 @@
+# Get the AWS Console URL of a CodePipeline pipeline
+set -eu
+
+: "${PIPELINE_NAME}"
+: "${REGION:=eu-west-2}"
+
+url="https://${REGION}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${PIPELINE_NAME}/view"
+echo "pipeline-url=$url" >> "$GITHUB_OUTPUT"

--- a/scripts/secure-pipelines/get-artifact-version.sh
+++ b/scripts/secure-pipelines/get-artifact-version.sh
@@ -1,0 +1,8 @@
+# Get version ID of an uploaded SAM artifact
+set -eu
+
+: "${ARTIFACT_BUCKET}" # The artifact upload bucket
+
+artifact=$(aws s3api head-object --bucket "$ARTIFACT_BUCKET" --key template.zip | jq '{VersionId, Metadata}')
+[[ $(jq --raw-output '.Metadata.commitsha' <<< "$artifact") != "$GITHUB_SHA" ]] && echo "Invalid commit SHA" && exit 1
+echo "artifact-version=$(jq --raw-output '.VersionId' <<< "$artifact")" >> "$GITHUB_OUTPUT"

--- a/secure-pipelines/await-pipeline-execution/action.yml
+++ b/secure-pipelines/await-pipeline-execution/action.yml
@@ -14,10 +14,12 @@ inputs:
   artifact-version:
     description: "Version of the artifact that triggered the execution"
     required: true
-  trigger-timeout:
-    description: "Maximum number of minutes to wait for the execution to start"
+  started-after:
+    description: "Only return an execution that started after the given timestamp"
     required: false
-    default: "5"
+  trigger-timeout:
+    description: "The maximum number of minutes to wait for the execution to start"
+    required: false
 runs:
   using: composite
   steps:
@@ -32,37 +34,17 @@ runs:
       id: get-execution-id
       shell: bash
       env:
-        PIPELINE: ${{ inputs.pipeline-name }}
-        VERSION: ${{ inputs.artifact-version }}
-        TIMEOUT_MINUTES: ${{ inputs.trigger-timeout }}
-      run: |
-        timeout=$((TIMEOUT_MINUTES * 60)) elapsed=0
-        echo -n "Waiting for the pipeline '$PIPELINE' to start execution..." 
-        query="pipelineExecutionSummaries[?contains(sourceRevisions[].revisionId, '$VERSION')]|[0].pipelineExecutionId"
-        
-        while [[ ${id:-None} == None ]] && [[ $elapsed -lt $timeout ]]; do
-          id=$(aws codepipeline list-pipeline-executions --pipeline-name "$PIPELINE" --query "$query" --output text)
-          echo -n "." && elapsed=$((elapsed + 5)) && sleep 5
-        done
-        
-        [[ ${id:-} ]] && echo "execution-id=$id" >> "$GITHUB_OUTPUT" && exit
-        echo "Pipeline \`$PIPELINE\` didn't start execution within the $TIMEOUT_MINUTES minute timeout" |
-          tee "$GITHUB_STEP_SUMMARY" && exit 1
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        TIMEOUT_MINS: ${{ inputs.trigger-timeout }}
+        REVISION_ID: ${{ inputs.artifact-version }}
+        STARTED_AFTER: ${{ inputs.started-after }}
+        EXECUTION_ID: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-execution-id.sh
+      run: $EXECUTION_ID
 
     - name: Await pipeline execution
       shell: bash
       env:
-        PIPELINE: ${{ inputs.pipeline-name }}
-        EXECUTION: ${{ steps.get-execution-id.outputs.execution-id }}
-      run: |
-        echo -n "Waiting for the pipeline '$PIPELINE' to finish execution..."
-        query="pipelineExecutionSummaries[?pipelineExecutionId=='$EXECUTION'].status"
-        
-        while [[ ${status:-InProgress} == InProgress ]]; do
-          status=$(aws codepipeline list-pipeline-executions --pipeline-name "$PIPELINE" --query "$query" --output text)
-          echo -n "." && sleep 5
-        done
-        
-        [[ $status == Succeeded ]] && exit
-        echo "Pipeline \`$PIPELINE\` finished execution with the status \`$status\`" |
-          tee "$GITHUB_STEP_SUMMARY" && exit 1
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        EXECUTION_ID: ${{ steps.get-execution-id.outputs.execution-id }}
+        AWAIT: ${{ github.action_path }}/../../scripts/aws/codepipeline/await-pipeline-execution.sh
+      run: $AWAIT

--- a/secure-pipelines/await-pipeline-execution/action.yml
+++ b/secure-pipelines/await-pipeline-execution/action.yml
@@ -1,0 +1,68 @@
+name: "Await pipeline execution for artifact version"
+description: "Wait for a pipeline to finish its execution for the given artifact version"
+inputs:
+  aws-role-arn:
+    description: "ARN of AWS role to assume when awaiting pipeline execution"
+    required: false
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
+  pipeline-name:
+    description: "Name of the pipeline to await"
+    required: true
+  artifact-version:
+    description: "Version of the artifact that triggered the execution"
+    required: true
+  trigger-timeout:
+    description: "Maximum number of minutes to wait for the execution to start"
+    required: false
+    default: "5"
+runs:
+  using: composite
+  steps:
+    - name: Assume AWS Role
+      if: ${{ inputs.aws-role-arn != null }}
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Get execution ID
+      id: get-execution-id
+      shell: bash
+      env:
+        PIPELINE: ${{ inputs.pipeline-name }}
+        VERSION: ${{ inputs.artifact-version }}
+        TIMEOUT_MINUTES: ${{ inputs.trigger-timeout }}
+      run: |
+        timeout=$((TIMEOUT_MINUTES * 60)) elapsed=0
+        echo -n "Waiting for the pipeline '$PIPELINE' to start execution..." 
+        query="pipelineExecutionSummaries[?contains(sourceRevisions[].revisionId, '$VERSION')]|[0].pipelineExecutionId"
+        
+        while [[ ${id:-None} == None ]] && [[ $elapsed -lt $timeout ]]; do
+          id=$(aws codepipeline list-pipeline-executions --pipeline-name "$PIPELINE" --query "$query" --output text)
+          echo -n "." && elapsed=$((elapsed + 5)) && sleep 5
+        done
+        
+        [[ ${id:-} ]] && echo "execution-id=$id" >> "$GITHUB_OUTPUT" && exit
+        echo "Pipeline \`$PIPELINE\` didn't start execution within the $TIMEOUT_MINUTES minute timeout" |
+          tee "$GITHUB_STEP_SUMMARY" && exit 1
+
+    - name: Await pipeline execution
+      shell: bash
+      env:
+        PIPELINE: ${{ inputs.pipeline-name }}
+        EXECUTION: ${{ steps.get-execution-id.outputs.execution-id }}
+      run: |
+        echo -n "Waiting for the pipeline '$PIPELINE' to finish execution..."
+        query="pipelineExecutionSummaries[?pipelineExecutionId=='$EXECUTION'].status"
+        
+        while [[ ${status:-InProgress} == InProgress ]]; do
+          status=$(aws codepipeline list-pipeline-executions --pipeline-name "$PIPELINE" --query "$query" --output text)
+          echo -n "." && sleep 5
+        done
+        
+        [[ $status == Succeeded ]] && exit
+        echo "Pipeline \`$PIPELINE\` finished execution with the status \`$status\`" |
+          tee "$GITHUB_STEP_SUMMARY" && exit 1

--- a/secure-pipelines/deploy-application/action.yml
+++ b/secure-pipelines/deploy-application/action.yml
@@ -1,5 +1,5 @@
-name: "Upload SAM package to secure pipelines"
-description: "Upload a SAM application package to an S3 bucket for deployment with secure pipelines"
+name: "Deploy an application through secure pipelines"
+description: "Upload a SAM package to secure pipelines and await pipeline execution for the uploaded artifact version"
 inputs:
   aws-role-arn:
     description: "ARN of AWS role to assume when uploading the package to S3"
@@ -14,6 +14,12 @@ inputs:
   signing-profile-name:
     description: "The name of the profile to use for code signing"
     required: true
+  pipeline-name:
+    description: "The name of the deployment pipeline"
+    required: true
+  trigger-timeout:
+    description: "The maximum number of minutes to wait for the pipeline execution to start"
+    required: false
   artifact-name:
     description: "Name of the artifact containing the built SAM application"
     required: false
@@ -28,16 +34,10 @@ inputs:
   working-directory:
     description: "The working directory containing the SAM app"
     required: false
-  pipeline-name:
-    description: "The name of the deployment pipeline"
-    required: false
 outputs:
   pipeline-url:
     description: "The URL of the pipeline consuming the uploaded artifact"
     value: ${{ steps.get-pipeline-url.outputs.pipeline-url }}
-  artifact-version:
-    description: "Version ID of the uploaded artifact"
-    value: ${{ steps.get-version.outputs.artifact-version }}
 runs:
   using: composite
   steps:
@@ -67,6 +67,11 @@ runs:
         VALIDATE: ${{ github.action_path }}/../../scripts/aws/sam/validate-template.sh
       run: $VALIDATE
 
+    - name: Get timestamp
+      id: get-timestamp
+      shell: bash
+      run: echo "timestamp=$(date)" >> "$GITHUB_OUTPUT"
+
     - name: Upload package
       uses: alphagov/di-devplatform-upload-action@v3.3
       with:
@@ -92,3 +97,22 @@ runs:
         PIPELINE_NAME: ${{ inputs.pipeline-name }}
         PIPELINE_URL: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-pipeline-url.sh
       run: $PIPELINE_URL
+
+    - name: Get execution ID
+      id: get-execution-id
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        TIMEOUT_MINS: ${{ inputs.trigger-timeout }}
+        REVISION_ID: ${{ steps.get-version.outputs.artifact-version }}
+        STARTED_AFTER: ${{ steps.get-timestamp.outputs.timestamp }}
+        EXECUTION_ID: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-execution-id.sh
+      run: $EXECUTION_ID
+
+    - name: Await pipeline execution
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        EXECUTION_ID: ${{ steps.get-execution-id.outputs.execution-id }}
+        AWAIT: ${{ github.action_path }}/../../scripts/aws/codepipeline/await-pipeline-execution.sh
+      run: $AWAIT

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -35,6 +35,9 @@ outputs:
   pipeline-url:
     description: "The URL of the pipeline consuming the uploaded artifact"
     value: ${{ steps.get-pipeline-url.outputs.pipeline-url }}
+  artifact-version:
+    description: "Version ID of the uploaded artifact"
+    value: ${{ steps.get-version.outputs.version }}
 runs:
   using: composite
   steps:
@@ -70,6 +73,16 @@ runs:
         artifact-bucket-name: ${{ inputs.artifact-bucket-name }}
         working-directory: ${{ inputs.working-directory }}
         template-file: ${{ inputs.template }}
+
+    - name: Get uploaded artifact version ID
+      id: get-version
+      shell: bash
+      env:
+        BUCKET: ${{ inputs.artifact-bucket-name }}
+      run: |
+        version=$(aws s3api head-object --bucket "$BUCKET" --key template.zip | jq '{VersionId, Metadata}')
+        [[ $(jq --raw-output '.Metadata.commitsha' <<< "$version") != "$GITHUB_SHA" ]] && echo "Invalid SHA" && exit 1
+        echo "version=$(jq --raw-output '.VersionId' <<< "$version")" >> "$GITHUB_OUTPUT"
 
     - name: Get pipeline URL
       id: get-pipeline-url

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -28,7 +28,6 @@ inputs:
   working-directory:
     description: "The working directory containing the SAM app"
     required: false
-    default: .
 runs:
   using: composite
   steps:
@@ -58,7 +57,7 @@ runs:
       run: $VALIDATE
 
     - name: Upload package
-      uses: alphagov/di-devplatform-upload-action@v3.2
+      uses: alphagov/di-devplatform-upload-action@v3.3
       with:
         signing-profile-name: ${{ inputs.signing-profile-name }}
         artifact-bucket-name: ${{ inputs.artifact-bucket-name }}

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -28,6 +28,13 @@ inputs:
   working-directory:
     description: "The working directory containing the SAM app"
     required: false
+  pipeline-name:
+    description: "The name of the deployment pipeline"
+    required: false
+outputs:
+  pipeline-url:
+    description: "The URL of the pipeline consuming the uploaded artifact"
+    value: ${{ steps.get-pipeline-url.outputs.pipeline-url }}
 runs:
   using: composite
   steps:
@@ -63,3 +70,14 @@ runs:
         artifact-bucket-name: ${{ inputs.artifact-bucket-name }}
         working-directory: ${{ inputs.working-directory }}
         template-file: ${{ inputs.template }}
+
+    - name: Get pipeline URL
+      id: get-pipeline-url
+      if: ${{ inputs.pipeline-name != null }}
+      shell: bash
+      env:
+        REGION: ${{ inputs.aws-region }}
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+      run: |
+        url="https://${REGION}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${PIPELINE_NAME}/view"
+        echo "pipeline-url=$url" >> "$GITHUB_OUTPUT"

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -57,6 +57,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: false
 
     - name: Validate SAM template
       shell: bash


### PR DESCRIPTION
**Add an action to await a secure pipeline execution for a given artifact version**

The action takes a pipeline name and an artifact ID and proceeds to:
1. Wait for the execution triggered by the artifact version to start
2. Wait for the execution to conclude and exits with an error code if the pipeline returns a failure result

**Add an action to deploy an application through secure pipelines**

The action uploads the artifact and then awaits the pipeline execution

---

- Remove default value for working directory as it is now optional in the di-devplatform-upload-action
- Construct pipeline URL when uploading a package to secure pipelines
- Output artifact version ID when uploading to secure pipelines