### PR TITLE
BAU: Mask Docker ECR password

### DIFF
--- a/aws/ecr/build-docker-image/action.yml
+++ b/aws/ecr/build-docker-image/action.yml
@@ -79,6 +79,8 @@ runs:
       if: ${{ inputs.registry == null }}
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+      with:
+        mask-password: true
 
     - name: Check image exists
       id: check-image-exists

--- a/aws/ecr/check-image-exists/action.yml
+++ b/aws/ecr/check-image-exists/action.yml
@@ -50,6 +50,8 @@ runs:
       if: ${{ inputs.registry == null }}
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+      with:
+        mask-password: true
 
     - name: Check image exists
       id: check-image-exists


### PR DESCRIPTION
The password output should be masked if not used to prevent it from being logged.