### PR TITLE
SSE-2649: Generate valid deployment names

### DIFF
--- a/.github/workflows/test-beautify-branch-name.yml
+++ b/.github/workflows/test-beautify-branch-name.yml
@@ -108,6 +108,32 @@ jobs:
           [[ ${{ steps.prepend-prefix.outputs.pretty-branch-name }} == prefix-long-branch-n ]]
 
 
+      - name: Don't generate a name ending with a hyphen
+        id: not-end-with-hyphen
+        uses: ./beautify-branch-name
+        with:
+          branch-name: branch-name
+          underscores-to-hyphens: true
+          length-limit: 7
+
+      - name: Verify generated name doesn't end with a hyphen
+        run: |
+          [[ ${{ steps.not-end-with-hyphen.outputs.pretty-branch-name }} == branch ]]
+
+
+      - name: Don't generate a name ending with a hyphen
+        id: not-end-with-underscore
+        uses: ./beautify-branch-name
+        with:
+          branch-name: branch_name
+          underscores-to-hyphens: false
+          length-limit: 7
+
+      - name: Verify generated name doesn't end with an underscore
+        run: |
+          [[ ${{ steps.not-end-with-underscore.outputs.pretty-branch-name }} == branch ]]
+
+
       - name: Validate length limit
         id: validate-length-limit
         continue-on-error: true

--- a/scripts/transform-branch-name.sh
+++ b/scripts/transform-branch-name.sh
@@ -13,9 +13,9 @@ if [[ $LENGTH_LIMIT -lt 1 ]]; then
   exit 1
 fi
 
+branch_name=$(echo "$branch_name" | cut -c1-"$LENGTH_LIMIT")
 branch_name=$(echo "$branch_name" | tr "." "_" | tr "/" "_")
 $DOWNCASE && branch_name=$(echo "$branch_name" | tr "[:upper:]" "[:lower:]")
 $REPLACE_UNDERSCORES && branch_name=$(echo "$branch_name" | tr "_" "-")
-branch_name=$(echo "$branch_name" | cut -c1-"$LENGTH_LIMIT")
 
-echo "$branch_name"
+echo "${branch_name%%[-_]}"


### PR DESCRIPTION
Ensure generated names don't end with a hyphen or underscore in the beautify branch name action