### PR TITLE
SSE-2685: Deploy to Fargate using secure pipelines

### DIFF
--- a/scripts/aws/codepipeline/await-pipeline-execution.sh
+++ b/scripts/aws/codepipeline/await-pipeline-execution.sh
@@ -4,7 +4,7 @@ set -eu
 : "${PIPELINE_NAME}"
 : "${EXECUTION_ID}"
 
-echo -n "Waiting for the pipeline '$PIPELINE_NAME' to finish execution \`$EXECUTION_ID\`..."
+echo -n "Waiting for the pipeline '$PIPELINE_NAME' to finish execution '$EXECUTION_ID'..."
 query="pipelineExecutionSummaries[?pipelineExecutionId=='$EXECUTION_ID'].status"
 
 while [[ ${status:-InProgress} == InProgress ]]; do

--- a/scripts/aws/codepipeline/get-execution-id.sh
+++ b/scripts/aws/codepipeline/get-execution-id.sh
@@ -9,7 +9,7 @@ set -eu
 [[ $STARTED_AFTER ]] && start=$(date --date="$STARTED_AFTER" +%s)
 [[ $TIMEOUT_MINS ]] && timeout=$((TIMEOUT_MINS * 60)) elapsed=0
 
-echo -n "Waiting for the pipeline '$PIPELINE_NAME' to start execution..."
+echo -n "Waiting for the pipeline '$PIPELINE_NAME' to start execution for revision '$REVISION_ID'..."
 query="pipelineExecutionSummaries[?contains(sourceRevisions[].revisionId, '$REVISION_ID')]|[0]"
 
 while true; do
@@ -17,7 +17,7 @@ while true; do
 
   if [[ $execution != null ]]; then
     [[ ${start:-} ]] || break
-    [[ $start < $(date --date="$(jq --raw-output '.startTime' <<< "$execution")" +s%) ]] && break
+    [[ $start < $(date --date="$(jq --raw-output '.startTime' <<< "$execution")" +%s) ]] && break
   fi
 
   [[ ${timeout:-} ]] && elapsed=$((elapsed + 5)) && [[ $elapsed -gt $timeout ]] && unset execution && break

--- a/scripts/aws/codepipeline/start-pipeline-execution.sh
+++ b/scripts/aws/codepipeline/start-pipeline-execution.sh
@@ -1,0 +1,8 @@
+# Start a pipeline execution and return the execution ID
+set -eu
+
+: "${PIPELINE_NAME}"
+
+id=$(aws codepipeline start-pipeline-execution --name "$PIPELINE_NAME" --output text)
+echo "Started execution for pipeline '$PIPELINE_NAME' with ID '$id'"
+echo "execution-id=$id" >> "$GITHUB_OUTPUT"

--- a/scripts/secure-pipelines/get-artifact-version.sh
+++ b/scripts/secure-pipelines/get-artifact-version.sh
@@ -1,8 +1,14 @@
 # Get version ID of an uploaded SAM artifact
 set -eu
 
-: "${ARTIFACT_BUCKET}" # The artifact upload bucket
+: "${ARTIFACT_BUCKET}"    # The artifact upload bucket
+: "${ERROR_STATUS:=true}" # Return error status if the artifact doesn't correspond to the commit SHA
 
-artifact=$(aws s3api head-object --bucket "$ARTIFACT_BUCKET" --key template.zip | jq '{VersionId, Metadata}')
-[[ $(jq --raw-output '.Metadata.commitsha' <<< "$artifact") != "$GITHUB_SHA" ]] && echo "Invalid commit SHA" && exit 1
+if ! artifact=$(aws s3api head-object --bucket "$ARTIFACT_BUCKET" --key template.zip) ||
+  [[ $(jq --raw-output '.Metadata.commitsha' <<< "$artifact") != "$GITHUB_SHA" ]]; then
+  $ERROR_STATUS || exit 0
+  echo "Artifact not found for commit SHA \`$GITHUB_SHA\`" | tee "$GITHUB_STEP_SUMMARY" && exit 1
+fi
+
 echo "artifact-version=$(jq --raw-output '.VersionId' <<< "$artifact")" >> "$GITHUB_OUTPUT"
+echo "artifact-timestamp=$(jq --raw-output '.LastModified' <<< "$artifact")" >> "$GITHUB_OUTPUT"

--- a/secure-pipelines/await-pipeline-execution/action.yml
+++ b/secure-pipelines/await-pipeline-execution/action.yml
@@ -12,14 +12,18 @@ inputs:
     description: "Name of the pipeline to await"
     required: true
   artifact-version:
-    description: "Version of the artifact that triggered the execution"
-    required: true
-  started-after:
-    description: "Only return an execution that started after the given timestamp"
+    description: "Uploaded artifact version that triggered an execution. Trigger a new pipeline execution if not set."
+    required: false
+  upload-timestamp:
+    description: "The timestamp the artifact was uploaded. Trigger a new pipeline execution if not set."
     required: false
   trigger-timeout:
     description: "The maximum number of minutes to wait for the execution to start"
     required: false
+  trigger-control:
+    description: "Whether to disable pipeline artifact upload trigger and let this action trigger deployment"
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -30,21 +34,47 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}
 
+    - name: Enable deployment stage
+      if: ${{ inputs.trigger-control == 'true' }}
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+      run: aws codepipeline enable-stage-transition --pipeline-name "$PIPELINE_NAME" \
+        --stage-name Deploy --transition-type Inbound
+
     - name: Get execution ID
+      if: ${{ inputs.artifact-version != null && inputs.upload-timestamp != null }}
       id: get-execution-id
       shell: bash
       env:
         PIPELINE_NAME: ${{ inputs.pipeline-name }}
         TIMEOUT_MINS: ${{ inputs.trigger-timeout }}
         REVISION_ID: ${{ inputs.artifact-version }}
-        STARTED_AFTER: ${{ inputs.started-after }}
+        STARTED_AFTER: ${{ inputs.upload-timestamp }}
         EXECUTION_ID: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-execution-id.sh
       run: $EXECUTION_ID
+
+    - name: Start pipeline execution
+      if: ${{ steps.get-execution-id.outcome == 'skipped' }}
+      id: start-execution
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        START_EXECUTION: ${{ github.action_path }}/../../scripts/aws/codepipeline/start-pipeline-execution.sh
+      run: $START_EXECUTION
 
     - name: Await pipeline execution
       shell: bash
       env:
         PIPELINE_NAME: ${{ inputs.pipeline-name }}
-        EXECUTION_ID: ${{ steps.get-execution-id.outputs.execution-id }}
+        EXECUTION_ID: ${{ steps.start-execution.outputs.execution-id || steps.get-execution-id.outputs.execution-id }}
         AWAIT: ${{ github.action_path }}/../../scripts/aws/codepipeline/await-pipeline-execution.sh
       run: $AWAIT
+
+    - name: Disable deployment stage
+      if: ${{ always() && inputs.trigger-control == 'true' }}
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+      run: aws codepipeline disable-stage-transition --pipeline-name "$PIPELINE_NAME" \
+        --stage-name Deploy --transition-type Inbound --reason "Deployment trigger controlled by GitHub Actions"

--- a/secure-pipelines/deploy-application/action.yml
+++ b/secure-pipelines/deploy-application/action.yml
@@ -34,6 +34,10 @@ inputs:
   working-directory:
     description: "The working directory containing the SAM app"
     required: false
+  force-upload:
+    description: "Upload a new package even if the artifact for the git SHA is already present in the S3 bucket"
+    required: false
+    default: "false"
 outputs:
   pipeline-url:
     description: "The URL of the pipeline consuming the uploaded artifact"
@@ -41,16 +45,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Pull repository
-      if: ${{ inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
-
-    - name: Get distribution artifact
-      if: ${{ inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ inputs.artifact-name }}
-
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
       uses: aws-actions/configure-aws-credentials@v2
@@ -59,7 +53,28 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         mask-aws-account-id: false
 
+    - name: Check artifact exists
+      if: ${{ inputs.force-upload != 'true' }}
+      id: check-artifact-exists
+      shell: bash
+      env:
+        ERROR_STATUS: "false"
+        ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
+        GET_VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
+      run: $GET_VERSION
+
+    - name: Pull repository
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.pull-repository == 'true' }}
+      uses: actions/checkout@v3
+
+    - name: Get distribution artifact
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifact-name }}
+
     - name: Validate SAM template
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
       shell: bash
       env:
         TEMPLATE: ${{ inputs.template }}
@@ -67,12 +82,8 @@ runs:
         VALIDATE: ${{ github.action_path }}/../../scripts/aws/sam/validate-template.sh
       run: $VALIDATE
 
-    - name: Get timestamp
-      id: get-timestamp
-      shell: bash
-      run: echo "timestamp=$(date)" >> "$GITHUB_OUTPUT"
-
     - name: Upload package
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
       uses: alphagov/di-devplatform-upload-action@v3.3
       with:
         signing-profile-name: ${{ inputs.signing-profile-name }}
@@ -81,38 +92,49 @@ runs:
         template-file: ${{ inputs.template }}
 
     - name: Get artifact version
-      id: get-version
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
+      id: get-uploaded-version
       shell: bash
       env:
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
-        VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
-      run: $VERSION
-
-    - name: Get pipeline URL
-      id: get-pipeline-url
-      if: ${{ inputs.pipeline-name != null }}
-      shell: bash
-      env:
-        REGION: ${{ inputs.aws-region }}
-        PIPELINE_NAME: ${{ inputs.pipeline-name }}
-        PIPELINE_URL: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-pipeline-url.sh
-      run: $PIPELINE_URL
+        GET_VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
+      run: $GET_VERSION
 
     - name: Get execution ID
+      if: ${{ steps.get-uploaded-version.outputs.artifact-version != null }}
       id: get-execution-id
       shell: bash
       env:
         PIPELINE_NAME: ${{ inputs.pipeline-name }}
         TIMEOUT_MINS: ${{ inputs.trigger-timeout }}
-        REVISION_ID: ${{ steps.get-version.outputs.artifact-version }}
-        STARTED_AFTER: ${{ steps.get-timestamp.outputs.timestamp }}
-        EXECUTION_ID: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-execution-id.sh
-      run: $EXECUTION_ID
+        REVISION_ID: ${{ steps.get-uploaded-version.outputs.artifact-version }}
+        STARTED_AFTER: ${{ steps.get-uploaded-version.outputs.artifact-timestamp }}
+        GET_EXECUTION_ID: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-execution-id.sh
+      run: $GET_EXECUTION_ID
+
+    - name: Start pipeline execution
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version != null }}
+      id: start-execution
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        START_EXECUTION: ${{ github.action_path }}/../../scripts/aws/codepipeline/start-pipeline-execution.sh
+      run: $START_EXECUTION
 
     - name: Await pipeline execution
       shell: bash
       env:
         PIPELINE_NAME: ${{ inputs.pipeline-name }}
-        EXECUTION_ID: ${{ steps.get-execution-id.outputs.execution-id }}
+        EXECUTION_ID: ${{ steps.start-execution.outputs.execution-id || steps.get-execution-id.outputs.execution-id }}
         AWAIT: ${{ github.action_path }}/../../scripts/aws/codepipeline/await-pipeline-execution.sh
       run: $AWAIT
+
+    - name: Get pipeline URL
+      if: ${{ always() }}
+      id: get-pipeline-url
+      shell: bash
+      env:
+        REGION: ${{ inputs.aws-region }}
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        GET_PIPELINE_URL: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-pipeline-url.sh
+      run: $GET_PIPELINE_URL

--- a/secure-pipelines/deploy-fargate/action.yml
+++ b/secure-pipelines/deploy-fargate/action.yml
@@ -1,0 +1,212 @@
+name: "Deploy a Fargate application through secure pipelines"
+description: "Push a Docker image, upload a SAM package and await pipeline execution for the uploaded artifact version"
+inputs:
+  aws-role-arn:
+    description: "ARN of AWS role to assume when uploading the package to S3"
+    required: true
+  aws-region:
+    description: "AWS region to use"
+    required: false
+    default: eu-west-2
+  artifact-bucket-name:
+    description: "The name of the bucket to upload the SAM artifact to"
+    required: true
+  container-signing-key-arn:
+    description: "The name of the profile to use for code signing"
+    required: true
+  pipeline-name:
+    description: "The name of the deployment pipeline"
+    required: true
+  ecr-repository:
+    description: "The ECR repository name to push the Docker image"
+    required: true
+  dockerfile:
+    description: "Filepath of the Docker file"
+    required: false
+  template:
+    description: "Filepath of the SAM application template"
+    required: false
+    default: template.yaml
+  build-directory:
+    description: "The base directory to use when building the SAM app"
+    required: false
+  docker-build-path:
+    description: "The base directory to use when building the docker image"
+    required: false
+  pull-repository:
+    description: "Pull the repository before uploading the package"
+    required: false
+    default: "true"
+  artifact-name:
+    description: "Name of the artifact containing the built SAM application"
+    required: false
+  artifact-path:
+    description: "Artifact destination path"
+    required: false
+  trigger-timeout:
+    description: "The maximum number of minutes to wait for the pipeline execution to start"
+    required: false
+  image-uri-param:
+    description: "The name of the image URI parameter in the CloudFormation template"
+    required: false
+    default: ImageURI
+outputs:
+  pipeline-url:
+    description: "The URL of the pipeline consuming the uploaded artifact"
+    value: ${{ steps.get-pipeline-url.outputs.pipeline-url }}
+runs:
+  using: composite
+  steps:
+    - name: Pull repository
+      if: ${{ inputs.pull-repository == 'true' }}
+      uses: actions/checkout@v3
+
+    - name: Get distribution artifact
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}
+
+    - name: Assume AWS Role
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
+        role-session-name: ${{ inputs.aws-session-name }}
+        aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: false
+
+    - name: Login to ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        mask-password: true
+
+    - name: Validate SAM template
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
+      shell: bash
+      env:
+        TEMPLATE: ${{ inputs.template }}
+        AWS_REGION: ${{ inputs.aws-region }}
+        VALIDATE: ${{ github.action_path }}/../../scripts/aws/sam/validate-template.sh
+      run: $VALIDATE
+
+    - name: Check artifact exists
+      id: check-artifact-exists
+      shell: bash
+      env:
+        ERROR_STATUS: "false"
+        ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
+        GET_VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
+      run: $GET_VERSION
+
+    - name: Check image exists
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
+      id: check-image-exists
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REPOSITORY: ${{ inputs.ecr-repository }}
+        IMAGE_TAGS: ${{ github.sha }}
+        VERBOSE: "true"
+        CHECK_IMAGE: ${{ github.action_path }}/../../scripts/aws/ecr/check-image-exists.sh
+      run: $CHECK_IMAGE
+
+    - name: Delete image
+      id: delete-image
+      if: ${{ steps.check-image-exists.outputs.image-digest != null }}
+      shell: bash
+      env:
+        IMAGE_DIGESTS: ${{ steps.check-image-exists.outputs.image-digest }}
+        REPOSITORY: ${{ inputs.ecr-repository }}
+        OUTPUT: ${{ runner.temp }}/delete-image.output
+        DELETE_IMAGES: ${{ github.action_path }}/../../scripts/aws/ecr/delete-images.sh
+      run: $DELETE_IMAGES >> "$OUTPUT"
+
+    - name: Report deleted image
+      if: ${{ always() && steps.delete-image.outcome != 'skipped' }}
+      shell: bash
+      env:
+        REPOSITORY: ${{ inputs.ecr-repository }}
+        RESULTS: ${{ runner.temp }}/delete-image.output
+        ERROR_STATUS: "true"
+        REPORT: ${{ github.action_path }}/../../scripts/aws/ecr/report-deleted-images.sh
+      run: $REPORT
+
+    - name: Get timestamp
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
+      id: get-timestamp
+      shell: bash
+      run: echo "timestamp=$(date)" >> "$GITHUB_OUTPUT"
+
+    - name: Set image URI
+      shell: bash
+      env:
+        PARAM: ${{ inputs.image-uri-param }}
+        COMMIT_SHA: ${{ github.sha }}
+        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REPOSITORY: ${{ inputs.ecr-repository }}
+        TEMPLATE: ${{ inputs.template }}
+      run: yq eval -i ".Parameters.$PARAM.Default=\"$REGISTRY/$REPOSITORY:$COMMIT_SHA\"" "$TEMPLATE"
+
+    - name: Push image and upload package
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
+      id: upload-package
+      uses: alphagov/di-devplatform-upload-action-ecr@1.0.4
+      with:
+        role-to-assume-arn: ${{ inputs.aws-role-arn }}
+        container-sign-kms-key-arn: ${{ inputs.container-signing-key-arn }}
+        template-file: ${{ inputs.template }}
+        sam-base-directory: ${{ inputs.build-directory }}
+        artifact-bucket-name: ${{ inputs.artifact-bucket-name }}
+        ecr-repo-name: ${{ inputs.ecr-repository }}
+        dockerfile: ${{ inputs.dockerfile }}
+        docker-build-path: ${{ inputs.docker-build-path }}
+        checkout-repo: false
+
+    - name: Get artifact version
+      if: ${{ steps.upload-package.outcome != 'skipped' }}
+      id: get-version
+      shell: bash
+      env:
+        ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
+        GET_VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
+      run: $GET_VERSION
+
+    - name: Get execution ID
+      if: ${{ steps.get-version.outputs.artifact-version != null }}
+      id: get-execution-id
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        TIMEOUT_MINS: ${{ inputs.trigger-timeout }}
+        REVISION_ID: ${{ steps.get-version.outputs.artifact-version }}
+        STARTED_AFTER: ${{ steps.get-timestamp.outputs.timestamp }}
+        GET_EXECUTION_ID: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-execution-id.sh
+      run: $GET_EXECUTION_ID
+
+    - name: Start pipeline execution
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version != null }}
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        START_EXECUTION: ${{ github.action_path }}/../../scripts/aws/codepipeline/start-pipeline-execution.sh
+      run: $START_EXECUTION
+
+    - name: Await pipeline execution
+      shell: bash
+      env:
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        EXECUTION_ID: ${{ steps.start-execution.outputs.execution-id || steps.get-execution-id.outputs.execution-id }}
+        AWAIT: ${{ github.action_path }}/../../scripts/aws/codepipeline/await-pipeline-execution.sh
+      run: $AWAIT
+
+    - name: Get pipeline URL
+      if: ${{ always() }}
+      id: get-pipeline-url
+      shell: bash
+      env:
+        REGION: ${{ inputs.aws-region }}
+        PIPELINE_NAME: ${{ inputs.pipeline-name }}
+        GET_PIPELINE_URL: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-pipeline-url.sh
+      run: $GET_PIPELINE_URL

--- a/secure-pipelines/upload-sam-package/action.yml
+++ b/secure-pipelines/upload-sam-package/action.yml
@@ -28,38 +28,42 @@ inputs:
   working-directory:
     description: "The working directory containing the SAM app"
     required: false
-  pipeline-name:
-    description: "The name of the deployment pipeline"
+  force-upload:
+    description: "Upload a new package even if the artifact for the git SHA is already present in the S3 bucket"
     required: false
 outputs:
-  pipeline-url:
-    description: "The URL of the pipeline consuming the uploaded artifact"
-    value: ${{ steps.get-pipeline-url.outputs.pipeline-url }}
   artifact-version:
     description: "Version ID of the uploaded artifact"
-    value: ${{ steps.get-version.outputs.artifact-version }}
+    value: ${{ steps.get-uploaded-version.outputs.artifact-version || check-artifact-exists.outputs.artifact-version }}
+  upload-timestamp:
+    description: "If the artifact has been uploaded, the timestamp it was last modified"
+    value: ${{ steps.get-uploaded-version.outputs.artifact-timestamp }}
 runs:
   using: composite
   steps:
-    - name: Pull repository
-      if: ${{ inputs.pull-repository == 'true' }}
-      uses: actions/checkout@v3
-
-    - name: Get distribution artifact
-      if: ${{ inputs.artifact-name != null }}
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ inputs.artifact-name }}
-
     - name: Assume AWS Role
       if: ${{ inputs.aws-role-arn != null }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}
-        mask-aws-account-id: false
+
+    - name: Check artifact exists
+      if: ${{ inputs.force-upload != 'true' }}
+      id: check-artifact-exists
+      shell: bash
+      env:
+        ERROR_STATUS: "false"
+        ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
+        GET_VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
+      run: $GET_VERSION
+
+    - name: Pull repository
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null inputs.pull-repository == 'true' }}
+      uses: actions/checkout@v3
 
     - name: Validate SAM template
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
       shell: bash
       env:
         TEMPLATE: ${{ inputs.template }}
@@ -67,7 +71,14 @@ runs:
         VALIDATE: ${{ github.action_path }}/../../scripts/aws/sam/validate-template.sh
       run: $VALIDATE
 
+    - name: Get distribution artifact
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null && inputs.artifact-name != null }}
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifact-name }}
+
     - name: Upload package
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
       uses: alphagov/di-devplatform-upload-action@v3.3
       with:
         signing-profile-name: ${{ inputs.signing-profile-name }}
@@ -76,19 +87,10 @@ runs:
         template-file: ${{ inputs.template }}
 
     - name: Get artifact version
-      id: get-version
+      if: ${{ steps.check-artifact-exists.outputs.artifact-version == null }}
+      id: get-uploaded-version
       shell: bash
       env:
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
-        VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
-      run: $VERSION
-
-    - name: Get pipeline URL
-      id: get-pipeline-url
-      if: ${{ inputs.pipeline-name != null }}
-      shell: bash
-      env:
-        REGION: ${{ inputs.aws-region }}
-        PIPELINE_NAME: ${{ inputs.pipeline-name }}
-        PIPELINE_URL: ${{ github.action_path }}/../../scripts/aws/codepipeline/get-pipeline-url.sh
-      run: $PIPELINE_URL
+        GET_VERSION: ${{ github.action_path }}/../../scripts/secure-pipelines/get-artifact-version.sh
+      run: $GET_VERSION


### PR DESCRIPTION
Add an action to deploy to Fargate using secure pipelines

**Check if the artifact exists before uploading a SAM package to secure pipelines**

Upload the artifact if the artifact in the S3 bucket doesn't correspond to the current commit SHA.
Otherwise, don't upload and trigger a pipeline execution instead.