### PR TITLE
Checkov GitHub Action fix

### DIFF
--- a/code-quality/run-checkov/action.yml
+++ b/code-quality/run-checkov/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.11.6'
         cache-dependency-path: ./.github/workflows
         cache: pip
 


### PR DESCRIPTION
# Code Changes
- use specific python version `3.11.6`

# Why
alphagov/di-github-actions/code-quality/run-checkov are all failing today due to one of the dependancies failing
and now It's started using python `3.12.0` version
But It to use Python 3.12 due to aiohttp and other dependencies not supporting 3.12 yet